### PR TITLE
el8-stream: drop advanced virtualization

### DIFF
--- a/ovirt-el8-stream-ppc64le-deps.repo.in
+++ b/ovirt-el8-stream-ppc64le-deps.repo.in
@@ -53,15 +53,6 @@ repo_gpgcheck=0
 enabled=1
 enabled_metadata=1
 
-# Once CentOS Stream will start providing 8.6 content we can drop this repo as
-# advanced virtualization is going to be included in AppStream.
-[ovirt-@OVIRT_SLOT@-centos-stream-advanced-virtualization-testing]
-name=Advanced Virtualization CentOS Stream testing packages for $basearch
-baseurl=https://buildlogs.centos.org/centos/8-stream/virt/$basearch/advancedvirt-common/
-enabled=1
-gpgcheck=0
-module_hotfixes=1
-
 [ovirt-@OVIRT_SLOT@-centos-stream-ovirt45-testing]
 name=CentOS Stream 8 - oVirt 4.5 - testing
 baseurl=https://buildlogs.centos.org/centos/8-stream/virt/$basearch/ovirt-45/

--- a/ovirt-el8-stream-x86_64-deps.repo.in
+++ b/ovirt-el8-stream-x86_64-deps.repo.in
@@ -58,15 +58,6 @@ repo_gpgcheck=0
 enabled=1
 enabled_metadata=1
 
-# Once CentOS Stream will start providing 8.6 content we can drop this repo as
-# advanced virtualization is going to be included in AppStream.
-[ovirt-@OVIRT_SLOT@-centos-stream-advanced-virtualization-testing]
-name=Advanced Virtualization CentOS Stream testing packages for $basearch
-baseurl=https://buildlogs.centos.org/centos/8-stream/virt/$basearch/advancedvirt-common/
-enabled=1
-gpgcheck=0
-module_hotfixes=1
-
 [ovirt-@OVIRT_SLOT@-centos-stream-ovirt45-testing]
 name=CentOS Stream 8 - oVirt 4.5 - testing
 baseurl=https://buildlogs.centos.org/centos/8-stream/virt/$basearch/ovirt-45/


### PR DESCRIPTION
Advanced virtualization is now included in AppStream: removing from needed repos for CentOS Stream.

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>