### PR TITLE
node: make ipa-client available as optional

### DIFF
--- a/node-optional.el8.repo
+++ b/node-optional.el8.repo
@@ -6,7 +6,43 @@ mirrorlist = http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=B
 gpgcheck = 1
 enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
-includepkgs = dnf-plugin-subscription-manager fcoe-utils python3-librepo subscription-manager usermode
+includepkgs =
+ # vdsm hooks
+ # https://bugzilla.redhat.com/show_bug.cgi?id=1947759
+ fcoe-utils
+ #
+ # subscription-manager
+ # https://bugzilla.redhat.com/show_bug.cgi?id=2006682
+ dnf-plugin-subscription-manager
+ python3-librepo
+ subscription-manager
+ usermode
+ #
+ # ipa-client
+ # https://bugzilla.redhat.com/show_bug.cgi?id=2017681
+ autofs
+ avahi-libs
+ cups-libs
+ krb5-workstation
+ libipa_hbac
+ libkadm5
+ libsss_autofs
+ libsss_simpleifp
+ libsss_sudo
+ libwbclient
+ python3-dns
+ python3-libipa_hbac
+ python3-sss
+ python3-sss-murmur
+ python3-sssdconfig
+ samba-client-libs
+ samba-common
+ samba-common-libs
+ sssd-common-pac
+ sssd-dbus
+ sssd-ipa
+ sssd-krb5-common
+ sssd-tools
 
 [onn-appstream]
 name = oVirt Node Optional packages from CentOS Stream $releasever - AppStream
@@ -14,4 +50,27 @@ mirrorlist = http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=A
 gpgcheck = 1
 enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
-includepkgs = vhostmd
+includepkgs =
+ # vdsm hooks
+ # https://bugzilla.redhat.com/show_bug.cgi?id=1947759
+ vhostmd
+ #
+ # ipa-client
+ # https://bugzilla.redhat.com/show_bug.cgi?id=2017681
+ certmonger
+ ipa-client
+ ipa-client-common
+ ipa-common
+ ipa-selinux
+ oddjob
+ oddjob-mkhomedir
+ python3-gssapi
+ python3-ipaclient
+ python3-ipalib
+ python3-jwcrypto
+ python3-ldap
+ python3-pyasn1
+ python3-pyasn1-modules
+ python3-pyusb
+ python3-qrcode-core
+ python3-yubico

--- a/node-optional.el9.repo
+++ b/node-optional.el9.repo
@@ -7,7 +7,25 @@ gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 gpgcheck = 1
 countme = 1
 enabled = 1
-includepkgs = fcoe-utils
+includepkgs =
+ # vdsm hooks
+ # https://bugzilla.redhat.com/show_bug.cgi?id=1947759
+ fcoe-utils
+
+[onn-appstream]
+name = oVirt Node Optional packages from CentOS Stream $releasever - AppStream
+metalink = https://mirrors.centos.org/metalink?repo=centos-appstream-$stream&arch=$basearch&protocol=https,http
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+gpgcheck = 1
+countme = 1
+enabled = 1
+includepkgs =
+ # ipa-client
+ # https://bugzilla.redhat.com/show_bug.cgi?id=2017681
+ ipa-client
+ ipa-client-common
+ ipa-common
+ ipa-selinux
 
 [onn-sap]
 name = oVirt Node Optional packages from CentOS Stream $releasever - SAP
@@ -15,4 +33,7 @@ baseurl = https://composes.stream.centos.org/production/latest-CentOS-Stream/com
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 gpgcheck = 1
 enabled = 1
-includepkgs = vhostmd
+includepkgs =
+ # vdsm hooks
+ # https://bugzilla.redhat.com/show_bug.cgi?id=1947759
+ vhostmd


### PR DESCRIPTION
Allowing to install ipa-client on oVirt Node as it's not installed by default anymore

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2017681
Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>