### PR TITLE
el9: repos: drop EL9 collection in favor of Virt SIG

### DIFF
--- a/ovirt-el9-stream-aarch64-deps.repo.in
+++ b/ovirt-el9-stream-aarch64-deps.repo.in
@@ -1,13 +1,3 @@
-[copr:copr.fedorainfracloud.org:sbonazzo:EL9Collection]
-name=Copr repo for EL9Collection owned by sbonazzo
-baseurl=https://download.copr.fedorainfracloud.org/results/sbonazzo/EL9Collection/centos-stream-9-$basearch/
-type=rpm-md
-gpgcheck=1
-gpgkey=https://download.copr.fedorainfracloud.org/results/sbonazzo/EL9Collection/pubkey.gpg
-repo_gpgcheck=0
-enabled=1
-enabled_metadata=1
-
 [ovirt-@OVIRT_SLOT@-centos-stream-ovirt45-testing]
 name=CentOS Stream 9 - oVirt 4.5 - testing
 baseurl=https://buildlogs.centos.org/centos/9-stream/virt/$basearch/ovirt-45/

--- a/ovirt-el9-stream-x86_64-deps.repo.in
+++ b/ovirt-el9-stream-x86_64-deps.repo.in
@@ -1,13 +1,3 @@
-[copr:copr.fedorainfracloud.org:sbonazzo:EL9Collection]
-name=Copr repo for EL9Collection owned by sbonazzo
-baseurl=https://download.copr.fedorainfracloud.org/results/sbonazzo/EL9Collection/centos-stream-9-$basearch/
-type=rpm-md
-gpgcheck=1
-gpgkey=https://download.copr.fedorainfracloud.org/results/sbonazzo/EL9Collection/pubkey.gpg
-repo_gpgcheck=0
-enabled=1
-enabled_metadata=1
-
 [ovirt-@OVIRT_SLOT@-centos-stream-ovirt45-testing]
 name=CentOS Stream 9 - oVirt 4.5 - testing
 baseurl=https://buildlogs.centos.org/centos/9-stream/virt/$basearch/ovirt-45/


### PR DESCRIPTION
needed packages should be shipped via Virt SIG.

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>