### PR TITLE
README: updated now pointing to github

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,22 @@
 # oVirt Release
 [![Copr build status](https://copr.fedorainfracloud.org/coprs/ovirt/ovirt-master-snapshot/package/ovirt-release/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/ovirt/ovirt-master-snapshot/package/ovirt-release/)
 
-Welcome to the oVirt Release source repository.
-
-This repository is hosted on [GitHub:ovirt-release](https://github.com/oVirt/ovirt-release)
+Welcome to the oVirt Release source repository. This repository is hosted on [GitHub:ovirt-release](https://github.com/oVirt/ovirt-release).
 
 ## How to contribute
 
+Your contributions are welcome.
+
 ### Submitting patches
 
-Patches are welcome!
-
-Please submit patches to [GitHub:ovirt-release](https://github.com/oVirt/ovirt-release).
-If you are not familiar with the process  you can read about [collaborating with pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests)
-on the GitHub website.
+Please submit patches to [GitHub:ovirt-release](https://github.com/oVirt/ovirt-release). If you are not familiar with the process, you can read about [collaborating with pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests) on the GitHub website.
 
 ### Found a bug or documentation issue?
-To submit a bug or suggest an enhancement for oVirt Release please use
-[oVirt Bugzilla for ovirt-release product](https://bugzilla.redhat.com/enter_bug.cgi?product=ovirt-release).
 
-If you haven't got a bugzilla account and you don't want to create one you can still report issues to https://github.com/oVirt/ovirt-release/issues .
+To submit a bug or suggest an enhancement for oVirt Release please use [oVirt Bugzilla for ovirt-release product](https://bugzilla.redhat.com/enter_bug.cgi?product=ovirt-release).
 
-If you find a documentation issue on the oVirt website please navigate and click "Report an issue on GitHub" in the page footer.
-
+If you don't have a Bugzilla account, you can still report [issues](https://github.com/oVirt/ovirt-release/issues). If you find a documentation issue on the oVirt website, please navigate to the page footer and click "Report an issue on GitHub".
 
 ## Still need help?
-If you have any other questions, please join [oVirt Users forum / mailing list](https://lists.ovirt.org/admin/lists/users.ovirt.org/) and ask there.
+
+If you have any other questions or suggestions, you can join and contact us on the [oVirt Users forum / mailing list](https://lists.ovirt.org/admin/lists/users.ovirt.org/).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Welcome to the oVirt Release source repository. This repository is hosted on [Gi
 
 ## How to contribute
 
-Your contributions are welcome.
+All contributions are welcome - patches, bug reports, and documentation issues.
 
 ### Submitting patches
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@
 
 Welcome to the oVirt Release source repository.
 
-This repository is hosted on [gerrit.ovirt.org:ovirt-release](https://gerrit.ovirt.org/#/admin/projects/ovirt-release)
-and a **backup** of it is hosted on [GitHub:ovirt-release](https://github.com/oVirt/ovirt-release)
-
+This repository is hosted on [GitHub:ovirt-release](https://github.com/oVirt/ovirt-release)
 
 ## How to contribute
 
@@ -13,20 +11,18 @@ and a **backup** of it is hosted on [GitHub:ovirt-release](https://github.com/oV
 
 Patches are welcome!
 
-Please submit patches to [gerrit.ovirt.org:ovirt-release](https://gerrit.ovirt.org/#/admin/projects/ovirt-release).
-If you are not familiar with the review process for Gerrit patches you can read about [Working with oVirt Gerrit](https://ovirt.org/develop/dev-process/working-with-gerrit.html)
-on the [oVirt](https://ovirt.org/) website.
-
-**NOTE**: We might not notice pull requests that you create on Github, because we only use Github for backups.
-
+Please submit patches to [GitHub:ovirt-release](https://github.com/oVirt/ovirt-release).
+If you are not familiar with the process  you can read about [collaborating with pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests)
+on the GitHub website.
 
 ### Found a bug or documentation issue?
 To submit a bug or suggest an enhancement for oVirt Release please use
 [oVirt Bugzilla for ovirt-release product](https://bugzilla.redhat.com/enter_bug.cgi?product=ovirt-release).
+
+If you haven't got a bugzilla account and you don't want to create one you can still report issues to https://github.com/oVirt/ovirt-release/issues .
 
 If you find a documentation issue on the oVirt website please navigate and click "Report an issue on GitHub" in the page footer.
 
 
 ## Still need help?
 If you have any other questions, please join [oVirt Users forum / mailing list](https://lists.ovirt.org/admin/lists/users.ovirt.org/) and ask there.
-```


### PR DESCRIPTION
The gerrit repository is now archived.
Moved the development to github.

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>