### PR TITLE
el8stream: CBS oVirt 4.5 module hotfix

### DIFF
--- a/ovirt-el8-ppc64le-deps.repo.in
+++ b/ovirt-el8-ppc64le-deps.repo.in
@@ -85,6 +85,7 @@ name=CentOS Stream 8 - oVirt 4.5 - testing
 baseurl=https://buildlogs.centos.org/centos/8-stream/virt/$basearch/ovirt-45/
 gpgcheck=0
 enabled=1
+module_hotfixes=1
 
 [ovirt-@OVIRT_SLOT@-centos-stream-gluster10-testing]
 name=CentOS Stream 8 - Glusterfs 10 - testing

--- a/ovirt-el8-stream-ppc64le-deps.repo.in
+++ b/ovirt-el8-stream-ppc64le-deps.repo.in
@@ -77,6 +77,7 @@ name=CentOS Stream 8 - oVirt 4.5 - testing
 baseurl=https://buildlogs.centos.org/centos/8-stream/virt/$basearch/ovirt-45/
 gpgcheck=0
 enabled=1
+module_hotfixes=1
 
 [ovirt-@OVIRT_SLOT@-centos-stream-gluster10-testing]
 name=CentOS Stream 8 - Glusterfs 10 - testing

--- a/ovirt-el8-stream-x86_64-deps.repo.in
+++ b/ovirt-el8-stream-x86_64-deps.repo.in
@@ -82,6 +82,7 @@ name=CentOS Stream 8 - oVirt 4.5 - testing
 baseurl=https://buildlogs.centos.org/centos/8-stream/virt/$basearch/ovirt-45/
 gpgcheck=0
 enabled=1
+module_hotfixes=1
 
 [ovirt-@OVIRT_SLOT@-centos-stream-gluster10-testing]
 name=CentOS Stream 8 - Glusterfs 10 - testing

--- a/ovirt-el8-x86_64-deps.repo.in
+++ b/ovirt-el8-x86_64-deps.repo.in
@@ -90,6 +90,7 @@ name=CentOS Stream 8 - oVirt 4.5 - testing
 baseurl=https://buildlogs.centos.org/centos/8-stream/virt/$basearch/ovirt-45/
 gpgcheck=0
 enabled=1
+module_hotfixes=1
 
 [ovirt-@OVIRT_SLOT@-centos-stream-gluster10-testing]
 name=CentOS Stream 8 - Glusterfs 10 - testing


### PR DESCRIPTION
Moving oVirt 4.5 repo on CentOS Build System to module hotfix.
It contains ant packages which are filtered out by modularity otherwise.

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>