### PR TITLE
Fixed commenting on second failure

### DIFF
--- a/.github/workflows/repoclosure.yml
+++ b/.github/workflows/repoclosure.yml
@@ -172,7 +172,7 @@ jobs:
             gh issue create --title "${TITLE}" --body "${MESSAGE}" --label "${LABEL}"
         else
             MESSAGE="The repoclosure CI job is still failing. Please investigate: https://github.com/oVirt/ovirt-release/actions/runs/${{ github.run_id }}"
-            gh issue comment --body "${MESSAGE}"
+            gh issue comment "${ISSUENO}" --body "${MESSAGE}"
         fi
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Changes introduced with this PR

This PR fixes a bug when a second failure is discovered on the repoclosure job.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] Yes