### PR TITLE
Drop sbonazzo:EL8_collection COPR repo

### DIFF
--- a/ovirt-el8-ppc64le-deps.repo.in
+++ b/ovirt-el8-ppc64le-deps.repo.in
@@ -51,16 +51,6 @@ baseurl=https://fedorapeople.org/groups/virt/virtio-win/repo/latest
 enabled=1
 gpgcheck=0
 
-[ovirt-@OVIRT_SLOT@-copr:copr.fedorainfracloud.org:sbonazzo:EL8_collection]
-name=Copr repo for EL8_collection owned by sbonazzo
-baseurl=https://copr-be.cloud.fedoraproject.org/results/sbonazzo/EL8_collection/epel-8-$basearch/
-type=rpm-md
-gpgcheck=1
-gpgkey=https://copr-be.cloud.fedoraproject.org/results/sbonazzo/EL8_collection/pubkey.gpg
-repo_gpgcheck=0
-enabled=1
-enabled_metadata=1
-
 [ovirt-@OVIRT_SLOT@-copr:copr.fedorainfracloud.org:sac:gluster-ansible]
 name=Copr repo for gluster-ansible owned by sac
 baseurl=https://copr-be.cloud.fedoraproject.org/results/sac/gluster-ansible/epel-8-x86_64/

--- a/ovirt-el8-stream-ppc64le-deps.repo.in
+++ b/ovirt-el8-stream-ppc64le-deps.repo.in
@@ -43,16 +43,6 @@ baseurl=https://fedorapeople.org/groups/virt/virtio-win/repo/latest
 enabled=1
 gpgcheck=0
 
-[ovirt-@OVIRT_SLOT@-copr:copr.fedorainfracloud.org:sbonazzo:EL8_collection]
-name=Copr repo for EL8_collection owned by sbonazzo
-baseurl=https://copr-be.cloud.fedoraproject.org/results/sbonazzo/EL8_collection/epel-8-$basearch/
-type=rpm-md
-gpgcheck=1
-gpgkey=https://copr-be.cloud.fedoraproject.org/results/sbonazzo/EL8_collection/pubkey.gpg
-repo_gpgcheck=0
-enabled=1
-enabled_metadata=1
-
 [ovirt-@OVIRT_SLOT@-copr:copr.fedorainfracloud.org:sac:gluster-ansible]
 name=Copr repo for gluster-ansible owned by sac
 baseurl=https://copr-be.cloud.fedoraproject.org/results/sac/gluster-ansible/epel-8-x86_64/

--- a/ovirt-el8-stream-x86_64-deps.repo.in
+++ b/ovirt-el8-stream-x86_64-deps.repo.in
@@ -48,16 +48,6 @@ baseurl=https://fedorapeople.org/groups/virt/virtio-win/repo/latest
 enabled=1
 gpgcheck=0
 
-[ovirt-@OVIRT_SLOT@-copr:copr.fedorainfracloud.org:sbonazzo:EL8_collection]
-name=Copr repo for EL8_collection owned by sbonazzo
-baseurl=https://copr-be.cloud.fedoraproject.org/results/sbonazzo/EL8_collection/epel-8-$basearch/
-type=rpm-md
-gpgcheck=1
-gpgkey=https://copr-be.cloud.fedoraproject.org/results/sbonazzo/EL8_collection/pubkey.gpg
-repo_gpgcheck=0
-enabled=1
-enabled_metadata=1
-
 [ovirt-@OVIRT_SLOT@-copr:copr.fedorainfracloud.org:sac:gluster-ansible]
 name=Copr repo for gluster-ansible owned by sac
 baseurl=https://copr-be.cloud.fedoraproject.org/results/sac/gluster-ansible/epel-8-x86_64/

--- a/ovirt-el8-x86_64-deps.repo.in
+++ b/ovirt-el8-x86_64-deps.repo.in
@@ -56,16 +56,6 @@ baseurl=https://fedorapeople.org/groups/virt/virtio-win/repo/latest
 enabled=1
 gpgcheck=0
 
-[ovirt-@OVIRT_SLOT@-copr:copr.fedorainfracloud.org:sbonazzo:EL8_collection]
-name=Copr repo for EL8_collection owned by sbonazzo
-baseurl=https://copr-be.cloud.fedoraproject.org/results/sbonazzo/EL8_collection/epel-8-$basearch/
-type=rpm-md
-gpgcheck=1
-gpgkey=https://copr-be.cloud.fedoraproject.org/results/sbonazzo/EL8_collection/pubkey.gpg
-repo_gpgcheck=0
-enabled=1
-enabled_metadata=1
-
 [ovirt-@OVIRT_SLOT@-copr:copr.fedorainfracloud.org:sac:gluster-ansible]
 name=Copr repo for gluster-ansible owned by sac
 baseurl=https://copr-be.cloud.fedoraproject.org/results/sac/gluster-ansible/epel-8-x86_64/


### PR DESCRIPTION
## Changes introduced with this PR

* Dropping a personal COPR repo used up to now due to missing packages in officiall repositories.
  Required packages for building and installing oVirt are now included either in oVirt branded COPR
  or in CentOS Virtualization SIG.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] yes