### PR TITLE
Close repoclosure issue on success

### DIFF
--- a/.github/workflows/repoclosure.yml
+++ b/.github/workflows/repoclosure.yml
@@ -155,6 +155,29 @@ jobs:
             --repo rdo-delorean-component-common \
             --repo rdo-delorean-component-network \
             --repo resilientstorage
+  close-issue-on-success:
+    name: Report workflow success
+    runs-on: ubuntu-latest
+    needs:
+    - copr-ovirt-master-snapshot-el8
+    - ovirt-master-centos-stream-ovirt45-testing-el8
+    - copr-ovirt-master-snapshot-el9
+    - ovirt-master-centos-stream-ovirt45-testing-el9
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Add comment about successful job
+      run: |
+        set -e
+        LABEL="repoclosure-failed"
+        ISSUENO=$(gh issue list -l $LABEL | awk ' { print $1 } ' | head -n 1)
+        if [ -z "$ISSUENO" ]; then
+            MESSAGE="✅ The repoclosure CI job is now [successful](https://github.com/oVirt/ovirt-release/actions/runs/${{ github.run_id }}), closing issue."
+            gh issue comment "${ISSUENO}" --body "${MESSAGE}"
+            gh issue close "${ISSUENO}"
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   open-issue-on-failure:
     name: Report workflow failure
     runs-on: ubuntu-latest
@@ -174,10 +197,10 @@ jobs:
         LABEL="repoclosure-failed"
         ISSUENO=$(gh issue list -l $LABEL | awk ' { print $1 } ' | head -n 1)
         if [ -z "$ISSUENO" ]; then
-            MESSAGE="The repoclosure CI job failed. Please investigate: https://github.com/oVirt/ovirt-release/actions/runs/${{ github.run_id }}"
+            MESSAGE="❌ The repoclosure CI job failed. [Please investigate.](https://github.com/oVirt/ovirt-release/actions/runs/${{ github.run_id }})"
             gh issue create --title "${TITLE}" --body "${MESSAGE}" --label "${LABEL}"
         else
-            MESSAGE="The repoclosure CI job is still failing. Please investigate: https://github.com/oVirt/ovirt-release/actions/runs/${{ github.run_id }}"
+            MESSAGE="❌ The repoclosure CI job is still failing. [Please investigate.](https://github.com/oVirt/ovirt-release/actions/runs/${{ github.run_id }})"
             gh issue comment "${ISSUENO}" --body "${MESSAGE}"
         fi
       env:

--- a/.github/workflows/repoclosure.yml
+++ b/.github/workflows/repoclosure.yml
@@ -166,7 +166,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Add comment about successful job
+    - name: Add a comment about successful job and close issue
       run: |
         set -e
         LABEL="repoclosure-failed"
@@ -190,7 +190,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Add comment about failed job
+    - name: Add a comment about failed job
       run: |
         set -e
         TITLE="Failed repoclosure job"


### PR DESCRIPTION
## Changes introduced with this PR

This PR adds a CI job to close the `repoclosure-failed` issue when it succeeds.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] Yes