### PR TITLE
packaging: Fixed the node-optional.repo issue

### DIFF
--- a/ovirt-release44.spec.in
+++ b/ovirt-release44.spec.in
@@ -527,7 +527,7 @@ systemctl restart cockpit.service >/dev/null 2>&1
 * Tue Aug 03 2021 Lev Veyde <lveyde@redhat.com> - 4.4.8-0.4.rc4
 - 4.4.8 RC4
 
-* Wed Jul 27 2021 Lev Veyde <lveyde@redhat.com> - 4.4.8-0.3.rc3
+* Wed Jul 28 2021 Lev Veyde <lveyde@redhat.com> - 4.4.8-0.3.rc3
 - 4.4.8 RC3
 
 * Tue Jul 20 2021 Lev Veyde <lveyde@redhat.com> - 4.4.8-0.2.rc2

--- a/ovirt-release44.spec.in
+++ b/ovirt-release44.spec.in
@@ -419,7 +419,15 @@ systemctl restart cockpit.service >/dev/null 2>&1
 # - vdsm-hooks and their deps (bz #1947759)
 # set-enabled is needed to keep the repo enabled when post-processing the image
 
-install -m 644 "%{_datadir}/%{package_name}/node-optional.repo" "%{_sysconfdir}/yum.repos.d/node-optional.repo"
+if [ -f "%{_datadir}/%{package_name}/node-optional.repo" ] ; then
+    install -m 644 "%{_datadir}/%{package_name}/node-optional.repo" "%{_sysconfdir}/yum.repos.d/node-optional.repo"
+elif [ -f "%{_datadir}/%{package_name}-pre/node-optional.repo" ] ; then
+    install -m 644 "%{_datadir}/%{package_name}-pre/node-optional.repo" "%{_sysconfdir}/yum.repos.d/node-optional.repo"
+elif [ -f "%{_datadir}/%{package_name}-tested/node-optional.repo" ] ; then
+    install -m 644 "%{_datadir}/%{package_name}-tested/node-optional.repo" "%{_sysconfdir}/yum.repos.d/node-optional.repo"
+elif [ -f "%{_datadir}/%{package_name}-snapshot/node-optional.repo" ] ; then
+    install -m 644 "%{_datadir}/%{package_name}-snapshot/node-optional.repo" "%{_sysconfdir}/yum.repos.d/node-optional.repo"
+fi
 
 PYTHON=$(command -v python3 || command -v python)
 


### PR DESCRIPTION
Previously the node-optional.repo was installing only on GA releases.
This patch fixes that, so it will be installed in other cases as well.

RHBZ#2036795

Signed-off-by: Lev Veyde <lveyde@redhat.com>

Fixes issue # (delete if not relevant)

## Changes introduced with this PR

* node-optional.repo file is now installed in /etc/yum.repos.d/ directory for pre-GA releases as well.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y] 