### PR TITLE
automation: Modify check patch to only install master release

### DIFF
--- a/.github/workflows/check-patch.yml
+++ b/.github/workflows/check-patch.yml
@@ -51,15 +51,8 @@ jobs:
       # The build produce also other packages like ovirt-release-host-node
       # which require the repos to be enabled by the ovirt-release-master package
       # in order to be installable.
-      if: contains(github.base_ref, 'master') || contains(github.ref, 'master')
       run: |
           yum install -y exported-artifacts/ovirt-release-master-4*noarch.rpm
-
-    - name: install 4.4 built rpm
-      # On 4.4 the release rpm has several variants. We need the snapshot one to be tested.
-      if: contains(github.base_ref, 'ovirt-4.4') || contains(github.ref, 'ovirt-4.4')
-      run: |
-          yum install -y exported-artifacts/ovirt-release44-snapshot-4*noarch.rpm
 
     - name: test project installation
       run: |


### PR DESCRIPTION
Previously we used unified check patch for both master and ovirt-4.4
branches, and tried to guess which version of ovirt-release we need
to install. This patch diverges the check patch for master branch.

Signed-off-by: Lev Veyde <lveyde@redhat.com>

## Changes introduced with this PR

* Diverges check patch for the master branch

## Are you the owner of the code you are sending in, or do you have permission of the owner?
[y]