### PR TITLE
Drop preview repos for ioprocess and imageio

### DIFF
--- a/ovirt-el8-stream-x86_64-deps.repo.in
+++ b/ovirt-el8-stream-x86_64-deps.repo.in
@@ -129,25 +129,3 @@ name=RDO Delorean Common - current
 baseurl=https://trunk.rdoproject.org/centos8-master/component/common/current/
 enabled=1
 gpgcheck=0
-
-[ovirt-@OVIRT_SLOT@-ovirt-imageio-preview]
-name=Copr repo for ovirt-imageio-preview owned by nsoffer
-baseurl=https://download.copr.fedorainfracloud.org/results/nsoffer/ovirt-imageio-preview/epel-8-$basearch/
-type=rpm-md
-skip_if_unavailable=True
-gpgcheck=1
-gpgkey=https://download.copr.fedorainfracloud.org/results/nsoffer/ovirt-imageio-preview/pubkey.gpg
-repo_gpgcheck=0
-enabled=1
-enabled_metadata=1
-
-[ovirt-@OVIRT_SLOT@-ioprocess-preview]
-name=Copr repo for iprocess-preview owned by nsoffer
-baseurl=https://download.copr.fedorainfracloud.org/results/nsoffer/ioprocess-preview/epel-8-$basearch/
-type=rpm-md
-skip_if_unavailable=True
-gpgcheck=1
-gpgkey=https://download.copr.fedorainfracloud.org/results/nsoffer/ioprocess-preview/pubkey.gpg
-repo_gpgcheck=0
-enabled=1
-enabled_metadata=1

--- a/ovirt-el8-x86_64-deps.repo.in
+++ b/ovirt-el8-x86_64-deps.repo.in
@@ -230,25 +230,3 @@ includepkgs=python3-os-brick
  python3-six
  python3-requests
  python3-psutil
-
-[ovirt-@OVIRT_SLOT@-ovirt-imageio-preview]
-name=Copr repo for ovirt-imageio-preview owned by nsoffer
-baseurl=https://download.copr.fedorainfracloud.org/results/nsoffer/ovirt-imageio-preview/epel-8-$basearch/
-type=rpm-md
-skip_if_unavailable=True
-gpgcheck=1
-gpgkey=https://download.copr.fedorainfracloud.org/results/nsoffer/ovirt-imageio-preview/pubkey.gpg
-repo_gpgcheck=0
-enabled=1
-enabled_metadata=1
-
-[ovirt-@OVIRT_SLOT@-ioprocess-preview]
-name=Copr repo for iprocess-preview owned by nsoffer
-baseurl=https://download.copr.fedorainfracloud.org/results/nsoffer/ioprocess-preview/epel-8-$basearch/
-type=rpm-md
-skip_if_unavailable=True
-gpgcheck=1
-gpgkey=https://download.copr.fedorainfracloud.org/results/nsoffer/ioprocess-preview/pubkey.gpg
-repo_gpgcheck=0
-enabled=1
-enabled_metadata=1

--- a/ovirt-el9-stream-aarch64-deps.repo.in
+++ b/ovirt-el9-stream-aarch64-deps.repo.in
@@ -59,23 +59,3 @@ name=RDO Delorean Common - current
 baseurl=https://trunk.rdoproject.org/centos9-master/component/common/current/
 enabled=1
 gpgcheck=0
-
-[ovirt-@OVIRT_SLOT@-ovirt-imageio-preview]
-name=Copr repo for ovirt-imageio-preview owned by nsoffer
-baseurl=https://download.copr.fedorainfracloud.org/results/nsoffer/ovirt-imageio-preview/centos-stream-9-$basearch/
-gpgcheck=1
-gpgkey=https://download.copr.fedorainfracloud.org/results/nsoffer/ovirt-imageio-preview/pubkey.gpg
-repo_gpgcheck=0
-enabled=1
-enabled_metadata=1
-
-[ovirt-@OVIRT_SLOT@-ioprocess-preview]
-name=Copr repo for ioprocess-preview owned by nsoffer
-baseurl=https://download.copr.fedorainfracloud.org/results/nsoffer/ioprocess-preview/centos-stream-9-$basearch/
-type=rpm-md
-skip_if_unavailable=True
-gpgcheck=1
-gpgkey=https://download.copr.fedorainfracloud.org/results/nsoffer/ioprocess-preview/pubkey.gpg
-repo_gpgcheck=0
-enabled=1
-enabled_metadata=1

--- a/ovirt-el9-stream-x86_64-deps.repo.in
+++ b/ovirt-el9-stream-x86_64-deps.repo.in
@@ -59,23 +59,3 @@ name=RDO Delorean Common - current
 baseurl=https://trunk.rdoproject.org/centos9-master/component/common/current/
 enabled=1
 gpgcheck=0
-
-[ovirt-@OVIRT_SLOT@-ovirt-imageio-preview]
-name=Copr repo for ovirt-imageio-preview owned by nsoffer
-baseurl=https://download.copr.fedorainfracloud.org/results/nsoffer/ovirt-imageio-preview/centos-stream-9-$basearch/
-gpgcheck=1
-gpgkey=https://download.copr.fedorainfracloud.org/results/nsoffer/ovirt-imageio-preview/pubkey.gpg
-repo_gpgcheck=0
-enabled=1
-enabled_metadata=1
-
-[ovirt-@OVIRT_SLOT@-ioprocess-preview]
-name=Copr repo for ioprocess-preview owned by nsoffer
-baseurl=https://download.copr.fedorainfracloud.org/results/nsoffer/ioprocess-preview/centos-stream-9-$basearch/
-type=rpm-md
-skip_if_unavailable=True
-gpgcheck=1
-gpgkey=https://download.copr.fedorainfracloud.org/results/nsoffer/ioprocess-preview/pubkey.gpg
-repo_gpgcheck=0
-enabled=1
-enabled_metadata=1


### PR DESCRIPTION

Fixes issue #78

## Changes introduced with this PR

* ioprocess and imageio are now built in copr within ovirt copr repo. Avoiding to provide them in multiple places as it ends up with breaking repository closure.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] yes