### PR TITLE
node-optional.el8: add missing deps for ipa-client

### DIFF
--- a/node-optional.el8.repo
+++ b/node-optional.el8.repo
@@ -43,6 +43,8 @@ includepkgs =
  sssd-ipa
  sssd-krb5-common
  sssd-tools
+ xmlrpc-c
+ xmlrpc-c-client
 
 [onn-appstream]
 name = oVirt Node Optional packages from CentOS Stream $releasever - AppStream
@@ -64,6 +66,7 @@ includepkgs =
  ipa-selinux
  oddjob
  oddjob-mkhomedir
+ python3-click
  python3-gssapi
  python3-ipaclient
  python3-ipalib


### PR DESCRIPTION
Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2017681

## Changes introduced with this PR

* Add missing deps for ipa-client on oVirt Node el8

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] yes