### PR TITLE
repos: switch to centos stream

### DIFF
--- a/.github/workflows/check-patch.yml
+++ b/.github/workflows/check-patch.yml
@@ -42,6 +42,11 @@ jobs:
           find tmp.repos -iname \*rpm -exec mv "{}" exported-artifacts/ \;
           mv ./*tar.gz exported-artifacts/
 
+    - name: Upload artifacts
+      uses: ovirt/upload-rpms-action@v2
+      with:
+        directory: exported-artifacts
+
     - name: install 4.4 built rpm
       # On 4.4 the release rpm has several variants. We need the snapshot one to be tested.
       # As current snapshot repository is broken, using released packages repo instead.
@@ -57,8 +62,3 @@ jobs:
           yum --downloadonly install -y exported-artifacts/*noarch.rpm
           yum --downloadonly install -y ovirt-engine ovirt-engine-setup-plugin-websocket-proxy
 
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: artifacts
-        path: exported-artifacts/

--- a/ovirt-el8-ppc64le-deps.repo.in
+++ b/ovirt-el8-ppc64le-deps.repo.in
@@ -96,6 +96,15 @@ gpgcheck=1
 enabled=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-OpsTools
 
+# Temporary hack as opstools has not been populated yet
+[ovirt-@OVIRT_SLOT@-centos-opstools-vault]
+name=CentOS-8 - OpsTools - collectd - vault
+baseurl=https://vault.centos.org/8.5.2111/opstools/$basearch/collectd-5/
+gpgcheck=1
+enabled=1
+gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-OpsTools
+
+
 [ovirt-@OVIRT_SLOT@-centos-nfv-openvswitch]
 name=CentOS-$releasever - NFV OpenvSwitch
 #baseurl=http://mirror.centos.org/centos/8-stream/nfv/$basearch/openvswitch-2/

--- a/ovirt-el8-ppc64le-deps.repo.in
+++ b/ovirt-el8-ppc64le-deps.repo.in
@@ -39,8 +39,8 @@ gpgkey=https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8
 
 [ovirt-@OVIRT_SLOT@-centos-gluster8]
 name=CentOS-$releasever - Gluster 8
-mirrorlist=http://mirrorlist.centos.org?arch=$basearch&release=$releasever&repo=storage-gluster-8
-#baseurl=http://mirror.centos.org/$contentdir/$releasever/storage/$basearch/gluster-8/
+mirrorlist=http://mirrorlist.centos.org?arch=$basearch&release=8-stream&repo=storage-gluster-8
+#baseurl=http://mirror.centos.org/$contentdir/8-stream/storage/$basearch/gluster-8/
 gpgcheck=1
 enabled=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Storage
@@ -71,43 +71,47 @@ repo_gpgcheck=0
 enabled=1
 enabled_metadata=1
 
-[ovirt-@OVIRT_SLOT@-advanced-virtualization]
-name=Advanced Virtualization packages for $basearch
-mirrorlist=http://mirrorlist.centos.org/?arch=$basearch&release=8&repo=virt-advanced-virtualization
-enabled=1
+[ovirt-@OVIRT_SLOT@-centos-advanced-virtualization]
+name=CentOS-$releasever - Advanced Virtualization
+mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=$basearch&repo=virt-advancedvirt-common
+#baseurl=http://mirror.centos.org/$contentdir/8-stream/virt/$basearch/advancedvirt-common/
 gpgcheck=1
-gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Virtualization
+enabled=1
 module_hotfixes=1
+gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Virtualization
 
 [ovirt-@OVIRT_SLOT@-centos-ovirt44]
-name=CentOS-8 - oVirt 4.4
-mirrorlist=http://mirrorlist.centos.org/?arch=$basearch&release=8&repo=virt-ovirt-44
-enabled=1
+name=CentOS-$releasever - oVirt 4.4
+mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=$basearch&repo=virt-ovirt-44
+#baseurl=http://mirror.centos.org/$contentdir/8-stream/virt/$basearch/ovirt-44/
 gpgcheck=1
+enabled=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Virtualization
 
 [ovirt-@OVIRT_SLOT@-centos-opstools]
 name=CentOS-8 - OpsTools - collectd
-mirrorlist=http://mirrorlist.centos.org/?arch=$basearch&release=$releasever&repo=opstools-collectd-5
+mirrorlist=http://mirrorlist.centos.org/?arch=$basearch&release=8-stream&repo=opstools-collectd-5
+#baseurl=http://mirror.centos.org/$contentdir/8-stream/opstools/$basearch/collectd-5/
 gpgcheck=1
 enabled=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-OpsTools
 
 [ovirt-@OVIRT_SLOT@-centos-nfv-openvswitch]
 name=CentOS-$releasever - NFV OpenvSwitch
-#baseurl=http://mirror.centos.org/centos/$releasever/nfv/$basearch/openvswitch-2/
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=nfv-openvswitch-2
+#baseurl=http://mirror.centos.org/centos/8-stream/nfv/$basearch/openvswitch-2/
+mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=$basearch&repo=nfv-openvswitch-2
 gpgcheck=1
 enabled=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-NFV
 module_hotfixes=1
 
 [ovirt-@OVIRT_SLOT@-centos-ceph-pacific]
-name=Ceph packages for $basearch
-baseurl=http://mirror.centos.org/centos/8/storage/$basearch/ceph-pacific
-enabled=1
+name=CentOS-$stream - Ceph Pacific
+mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=$basearch&repo=storage-ceph-pacific
+#baseurl=http://mirror.centos.org/$contentdir/8-stream/storage/$basearch/ceph-pacific/
 priority=2
 gpgcheck=1
+enabled=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Storage
 includepkgs=ceph-common
  gperftools-libs
@@ -127,13 +131,14 @@ includepkgs=ceph-common
  python3-rbd
  python3-rgw
 
-[ovirt-@OVIRT_SLOT@-openstack-victoria]
-name=OpenStack Victoria Repository
-baseurl=http://mirror.centos.org/centos/$releasever/cloud/$basearch/openstack-victoria/
+[ovirt-@OVIRT_SLOT@-centos-openstack-victoria]
+name=CentOS-$releasever - OpenStack victoria
+#baseurl=http://mirror.centos.org/$contentdir/8-stream/cloud/$basearch/openstack-victoria/
+mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=$basearch&repo=cloud-openstack-victoria
 gpgcheck=1
 enabled=1
-module_hotfixes=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Cloud
+module_hotfixes=1
 includepkgs=python3-os-brick
  python3-cinderlib
  openstack-cinder

--- a/ovirt-el8-stream-ppc64le-deps.repo.in
+++ b/ovirt-el8-stream-ppc64le-deps.repo.in
@@ -96,6 +96,14 @@ gpgcheck=1
 enabled=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-OpsTools
 
+# Temporary hack as opstools has not been populated yet
+[ovirt-@OVIRT_SLOT@-centos-opstools-vault]
+name=CentOS-8 - OpsTools - collectd - vault
+baseurl=https://vault.centos.org/8.5.2111/opstools/$basearch/collectd-5/
+gpgcheck=1
+enabled=1
+gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-OpsTools
+
 [ovirt-@OVIRT_SLOT@-centos-nfv-openvswitch]
 name=CentOS-$releasever - NFV OpenvSwitch
 #baseurl=http://mirror.centos.org/centos/$stream/nfv/$basearch/openvswitch-2/

--- a/ovirt-el8-stream-ppc64le-deps.repo.in
+++ b/ovirt-el8-stream-ppc64le-deps.repo.in
@@ -38,9 +38,9 @@ gpgcheck=1
 gpgkey=https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8
 
 [ovirt-@OVIRT_SLOT@-centos-gluster8]
-name=CentOS-$releasever - Gluster 8
-mirrorlist=http://mirrorlist.centos.org?arch=$basearch&release=$releasever&repo=storage-gluster-8
-#baseurl=http://mirror.centos.org/$contentdir/$releasever/storage/$basearch/gluster-8/
+name=CentOS-$stream - Gluster 8
+mirrorlist=http://mirrorlist.centos.org?arch=$basearch&release=$stream&repo=storage-gluster-8
+#baseurl=http://mirror.centos.org/$contentdir/$stream/storage/$basearch/gluster-8/
 gpgcheck=1
 enabled=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Storage
@@ -71,52 +71,47 @@ repo_gpgcheck=0
 enabled=1
 enabled_metadata=1
 
-[ovirt-@OVIRT_SLOT@-advanced-virtualization]
-name=Advanced Virtualization packages for $basearch
-mirrorlist=http://mirrorlist.centos.org/?arch=$basearch&release=8&repo=virt-advanced-virtualization
+[ovirt-@OVIRT_SLOT@-centos-advanced-virtualization]
+name=CentOS-$releasever - Advanced Virtualization
+mirrorlist=http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=virt-advancedvirt-common
+#baseurl=http://mirror.centos.org/$contentdir/$stream/virt/$basearch/advancedvirt-common/
+gpgcheck=1
 enabled=1
-gpgcheck=1
-gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Virtualization
 module_hotfixes=1
-
-[ovirt-@OVIRT_SLOT@-centos-stream-advanced-virtualization]
-name=Advanced Virtualization CentOS Stream packages for $basearch
-baseurl=http://mirror.centos.org/centos/8-stream/virt/$basearch/advancedvirt-common/
-# On Apr 15th 2021 ppc64le repo for advanced virtualization is missing.
-# Keeping it here disabled waiting for the repo to be made available.
-enabled=0
-gpgcheck=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Virtualization
-module_hotfixes=1
 
-[ovirt-@OVIRT_SLOT@-centos-stream-ovirt44]
-name=CentOS-8 Stream - oVirt 4.4
-baseurl=http://mirror.centos.org/centos/8-stream/virt/$basearch/ovirt-44/
+[ovirt-@OVIRT_SLOT@-centos-ovirt44]
+name=CentOS-$releasever - oVirt 4.4
+mirrorlist=http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=virt-ovirt-44
+#baseurl=http://mirror.centos.org/$contentdir/$stream/virt/$basearch/ovirt-44/
+gpgcheck=1
 enabled=1
-gpgcheck=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Virtualization
 
 [ovirt-@OVIRT_SLOT@-centos-opstools]
 name=CentOS-8 - OpsTools - collectd
-mirrorlist=http://mirrorlist.centos.org/?arch=$basearch&release=$releasever&repo=opstools-collectd-5
+mirrorlist=http://mirrorlist.centos.org/?arch=$basearch&release=$stream&repo=opstools-collectd-5
+#baseurl=http://mirror.centos.org/$contentdir/$stream/opstools/$basearch/collectd-5/
 gpgcheck=1
 enabled=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-OpsTools
 
-[ovirt-@OVIRT_SLOT@-centos-stream-nfv-openvswitch]
+[ovirt-@OVIRT_SLOT@-centos-nfv-openvswitch]
 name=CentOS-$releasever - NFV OpenvSwitch
-baseurl=http://mirror.centos.org/centos/8-stream/nfv/$basearch/openvswitch-2/
+#baseurl=http://mirror.centos.org/centos/$stream/nfv/$basearch/openvswitch-2/
+mirrorlist=http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=nfv-openvswitch-2
 gpgcheck=1
 enabled=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-NFV
 module_hotfixes=1
 
 [ovirt-@OVIRT_SLOT@-centos-ceph-pacific]
-name=Ceph packages for $basearch
-baseurl=http://mirror.centos.org/centos/8-stream/storage/$basearch/ceph-pacific
+name=CentOS-$stream - Ceph Pacific
+mirrorlist=http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=storage-ceph-pacific
+#baseurl=http://mirror.centos.org/$contentdir/$stream/storage/$basearch/ceph-pacific/
+gpgcheck=1
 enabled=1
 priority=2
-gpgcheck=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Storage
 includepkgs=ceph-common
  gperftools-libs
@@ -136,13 +131,14 @@ includepkgs=ceph-common
  python3-rbd
  python3-rgw
 
-[ovirt-@OVIRT_SLOT@-openstack-victoria]
-name=OpenStack Victoria Repository
-baseurl=http://mirror.centos.org/centos/$releasever/cloud/$basearch/openstack-victoria/
+[ovirt-@OVIRT_SLOT@-centos-openstack-victoria]
+name=CentOS-$releasever - OpenStack victoria
+#baseurl=http://mirror.centos.org/$contentdir/$stream/cloud/$basearch/openstack-victoria/
+mirrorlist=http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=cloud-openstack-victoria
 gpgcheck=1
 enabled=1
-module_hotfixes=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Cloud
+module_hotfixes=1
 includepkgs=python3-os-brick
  python3-cinderlib
  openstack-cinder

--- a/ovirt-el8-stream-x86_64-deps.repo.in
+++ b/ovirt-el8-stream-x86_64-deps.repo.in
@@ -43,9 +43,9 @@ gpgcheck=1
 gpgkey=https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8
 
 [ovirt-@OVIRT_SLOT@-centos-gluster8]
-name=CentOS-$releasever - Gluster 8
-mirrorlist=http://mirrorlist.centos.org?arch=$basearch&release=$releasever&repo=storage-gluster-8
-#baseurl=http://mirror.centos.org/$contentdir/$releasever/storage/$basearch/gluster-8/
+name=CentOS-$stream - Gluster 8
+mirrorlist=http://mirrorlist.centos.org?arch=$basearch&release=$stream&repo=storage-gluster-8
+#baseurl=http://mirror.centos.org/$contentdir/$stream/storage/$basearch/gluster-8/
 gpgcheck=1
 enabled=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Storage
@@ -76,42 +76,47 @@ repo_gpgcheck=0
 enabled=1
 enabled_metadata=1
 
-[ovirt-@OVIRT_SLOT@-centos-stream-advanced-virtualization]
-name=Advanced Virtualization CentOS Stream packages for $basearch
-baseurl=http://mirror.centos.org/centos/8-stream/virt/$basearch/advancedvirt-common/
-enabled=1
+[ovirt-@OVIRT_SLOT@-centos-advanced-virtualization]
+name=CentOS-$releasever - Advanced Virtualization
+mirrorlist=http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=virt-advancedvirt-common
+#baseurl=http://mirror.centos.org/$contentdir/$stream/virt/$basearch/advancedvirt-common/
 gpgcheck=1
-gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Virtualization
+enabled=1
 module_hotfixes=1
+gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Virtualization
 
-[ovirt-@OVIRT_SLOT@-centos-stream-ovirt44]
-name=CentOS-8 Stream - oVirt 4.4
-baseurl=http://mirror.centos.org/centos/8-stream/virt/$basearch/ovirt-44/
-enabled=1
+[ovirt-@OVIRT_SLOT@-centos-ovirt44]
+name=CentOS-$releasever - oVirt 4.4
+mirrorlist=http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=virt-ovirt-44
+#baseurl=http://mirror.centos.org/$contentdir/$stream/virt/$basearch/ovirt-44/
 gpgcheck=1
+enabled=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Virtualization
 
 [ovirt-@OVIRT_SLOT@-centos-opstools]
 name=CentOS-8 - OpsTools - collectd
-mirrorlist=http://mirrorlist.centos.org/?arch=$basearch&release=$releasever&repo=opstools-collectd-5
+mirrorlist=http://mirrorlist.centos.org/?arch=$basearch&release=$stream&repo=opstools-collectd-5
+#baseurl=http://mirror.centos.org/$contentdir/$stream/opstools/$basearch/collectd-5/
 gpgcheck=1
 enabled=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-OpsTools
 
-[ovirt-@OVIRT_SLOT@-centos-stream-nfv-openvswitch]
+[ovirt-@OVIRT_SLOT@-centos-nfv-openvswitch]
 name=CentOS-$releasever - NFV OpenvSwitch
-baseurl=http://mirror.centos.org/centos/8-stream/nfv/$basearch/openvswitch-2/
+#baseurl=http://mirror.centos.org/centos/$stream/nfv/$basearch/openvswitch-2/
+mirrorlist=http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=nfv-openvswitch-2
 gpgcheck=1
 enabled=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-NFV
 module_hotfixes=1
 
 [ovirt-@OVIRT_SLOT@-centos-ceph-pacific]
-name=Ceph packages for $basearch
-baseurl=http://mirror.centos.org/centos/8-stream/storage/$basearch/ceph-pacific
+name=CentOS-$stream - Ceph Pacific
+mirrorlist=http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=storage-ceph-pacific
+#baseurl=http://mirror.centos.org/$contentdir/$stream/storage/$basearch/ceph-pacific/
+gpgcheck=1
 enabled=1
 priority=2
-gpgcheck=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Storage
 includepkgs=ceph-common
  gperftools-libs
@@ -131,13 +136,14 @@ includepkgs=ceph-common
  python3-rbd
  python3-rgw
 
-[ovirt-@OVIRT_SLOT@-openstack-victoria]
-name=OpenStack Victoria Repository
-baseurl=http://mirror.centos.org/centos/$releasever/cloud/$basearch/openstack-victoria/
+[ovirt-@OVIRT_SLOT@-centos-openstack-victoria]
+name=CentOS-$releasever - OpenStack victoria
+#baseurl=http://mirror.centos.org/$contentdir/$stream/cloud/$basearch/openstack-victoria/
+mirrorlist=http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=cloud-openstack-victoria
 gpgcheck=1
 enabled=1
-module_hotfixes=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Cloud
+module_hotfixes=1
 includepkgs=python3-os-brick
  python3-cinderlib
  openstack-cinder

--- a/ovirt-el8-stream-x86_64-deps.repo.in
+++ b/ovirt-el8-stream-x86_64-deps.repo.in
@@ -101,6 +101,14 @@ gpgcheck=1
 enabled=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-OpsTools
 
+# Temporary hack as opstools has not been populated yet
+[ovirt-@OVIRT_SLOT@-centos-opstools-vault]
+name=CentOS-8 - OpsTools - collectd - vault
+baseurl=https://vault.centos.org/8.5.2111/opstools/$basearch/collectd-5/
+gpgcheck=1
+enabled=1
+gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-OpsTools
+
 [ovirt-@OVIRT_SLOT@-centos-nfv-openvswitch]
 name=CentOS-$releasever - NFV OpenvSwitch
 #baseurl=http://mirror.centos.org/centos/$stream/nfv/$basearch/openvswitch-2/

--- a/ovirt-el8-x86_64-deps.repo.in
+++ b/ovirt-el8-x86_64-deps.repo.in
@@ -44,8 +44,8 @@ gpgkey=https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8
 
 [ovirt-@OVIRT_SLOT@-centos-gluster8]
 name=CentOS-$releasever - Gluster 8
-mirrorlist=http://mirrorlist.centos.org?arch=$basearch&release=$releasever&repo=storage-gluster-8
-#baseurl=http://mirror.centos.org/$contentdir/$releasever/storage/$basearch/gluster-8/
+mirrorlist=http://mirrorlist.centos.org?arch=$basearch&release=8-stream&repo=storage-gluster-8
+#baseurl=http://mirror.centos.org/$contentdir/8-stream/storage/$basearch/gluster-8/
 gpgcheck=1
 enabled=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Storage
@@ -76,43 +76,47 @@ repo_gpgcheck=0
 enabled=1
 enabled_metadata=1
 
-[ovirt-@OVIRT_SLOT@-advanced-virtualization]
-name=Advanced Virtualization packages for $basearch
-mirrorlist=http://mirrorlist.centos.org/?arch=$basearch&release=8&repo=virt-advanced-virtualization
-enabled=1
+[ovirt-@OVIRT_SLOT@-centos-advanced-virtualization]
+name=CentOS-$releasever - Advanced Virtualization
+mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=$basearch&repo=virt-advancedvirt-common
+#baseurl=http://mirror.centos.org/$contentdir/8-stream/virt/$basearch/advancedvirt-common/
 gpgcheck=1
-gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Virtualization
+enabled=1
 module_hotfixes=1
+gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Virtualization
 
 [ovirt-@OVIRT_SLOT@-centos-ovirt44]
-name=CentOS-8 - oVirt 4.4
-mirrorlist=http://mirrorlist.centos.org/?arch=$basearch&release=8&repo=virt-ovirt-44
-enabled=1
+name=CentOS-$releasever - oVirt 4.4
+mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=$basearch&repo=virt-ovirt-44
+#baseurl=http://mirror.centos.org/$contentdir/8-stream/virt/$basearch/ovirt-44/
 gpgcheck=1
+enabled=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Virtualization
 
 [ovirt-@OVIRT_SLOT@-centos-opstools]
 name=CentOS-8 - OpsTools - collectd
-mirrorlist=http://mirrorlist.centos.org/?arch=$basearch&release=$releasever&repo=opstools-collectd-5
+mirrorlist=http://mirrorlist.centos.org/?arch=$basearch&release=8-stream&repo=opstools-collectd-5
+#baseurl=http://mirror.centos.org/$contentdir/8-stream/opstools/$basearch/collectd-5/
 gpgcheck=1
 enabled=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-OpsTools
 
 [ovirt-@OVIRT_SLOT@-centos-nfv-openvswitch]
 name=CentOS-$releasever - NFV OpenvSwitch
-#baseurl=http://mirror.centos.org/centos/$releasever/nfv/$basearch/openvswitch-2/
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=nfv-openvswitch-2
+#baseurl=http://mirror.centos.org/centos/8-stream/nfv/$basearch/openvswitch-2/
+mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=$basearch&repo=nfv-openvswitch-2
 gpgcheck=1
 enabled=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-NFV
 module_hotfixes=1
 
 [ovirt-@OVIRT_SLOT@-centos-ceph-pacific]
-name=Ceph packages for $basearch
-baseurl=http://mirror.centos.org/centos/8/storage/$basearch/ceph-pacific
-enabled=1
+name=CentOS-$stream - Ceph Pacific
+mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=$basearch&repo=storage-ceph-pacific
+#baseurl=http://mirror.centos.org/$contentdir/8-stream/storage/$basearch/ceph-pacific/
 priority=2
 gpgcheck=1
+enabled=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Storage
 includepkgs=ceph-common
  gperftools-libs
@@ -132,13 +136,14 @@ includepkgs=ceph-common
  python3-rbd
  python3-rgw
 
-[ovirt-@OVIRT_SLOT@-openstack-victoria]
-name=OpenStack Victoria Repository
-baseurl=http://mirror.centos.org/centos/$releasever/cloud/$basearch/openstack-victoria/
+[ovirt-@OVIRT_SLOT@-centos-openstack-victoria]
+name=CentOS-$releasever - OpenStack victoria
+#baseurl=http://mirror.centos.org/$contentdir/8-stream/cloud/$basearch/openstack-victoria/
+mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=$basearch&repo=cloud-openstack-victoria
 gpgcheck=1
 enabled=1
-module_hotfixes=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Cloud
+module_hotfixes=1
 includepkgs=python3-os-brick
  python3-cinderlib
  openstack-cinder

--- a/ovirt-el8-x86_64-deps.repo.in
+++ b/ovirt-el8-x86_64-deps.repo.in
@@ -101,6 +101,14 @@ gpgcheck=1
 enabled=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-OpsTools
 
+# Temporary hack as opstools has not been populated yet
+[ovirt-@OVIRT_SLOT@-centos-opstools-vault]
+name=CentOS-8 - OpsTools - collectd - vault
+baseurl=https://vault.centos.org/8.5.2111/opstools/$basearch/collectd-5/
+gpgcheck=1
+enabled=1
+gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-OpsTools
+
 [ovirt-@OVIRT_SLOT@-centos-nfv-openvswitch]
 name=CentOS-$releasever - NFV OpenvSwitch
 #baseurl=http://mirror.centos.org/centos/8-stream/nfv/$basearch/openvswitch-2/


### PR DESCRIPTION
Fixes issue #91

## Changes introduced with this PR

* CentOS Linux 8 repos are going to be archived to the vault and it won't be possible to update them anymore.
  Preparing to switch to the repos provided for CentOS Stream also for Rocky and Alma.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] yes