### PR TITLE
node-optional.el9: add missing deps for ipa-client

### DIFF
--- a/node-optional.el9.repo
+++ b/node-optional.el9.repo
@@ -11,6 +11,31 @@ includepkgs =
  # vdsm hooks
  # https://bugzilla.redhat.com/show_bug.cgi?id=1947759
  fcoe-utils
+ # ipa-client
+ # https://bugzilla.redhat.com/show_bug.cgi?id=2017681
+ autofs
+ cups-libs
+ dbus-tools
+ krb5-pkinit
+ krb5-workstation
+ libipa_hbac
+ libkadm5
+ libsss_autofs
+ libwbclient
+ python3-dns
+ python3-libipa_hbac
+ python3-sss
+ python3-sss-murmur
+ python3-sssdconfig
+ samba-client-libs
+ samba-common
+ samba-common-libs
+ sssd-common-pac
+ sssd-dbus
+ sssd-ipa
+ sssd-krb5-common
+ sssd-tools
+
 
 [onn-appstream]
 name = oVirt Node Optional packages from CentOS Stream $releasever - AppStream
@@ -22,10 +47,27 @@ enabled = 1
 includepkgs =
  # ipa-client
  # https://bugzilla.redhat.com/show_bug.cgi?id=2017681
+ certmonger
  ipa-client
  ipa-client-common
  ipa-common
  ipa-selinux
+ oddjob
+ oddjob-mkhomedir
+ python3-babel
+ python3-gssapi
+ python3-ipaclient
+ python3-ipalib
+ python3-jinja2
+ python3-jwcrypto
+ python3-ldap
+ python3-markupsafe
+ python3-pyasn1
+ python3-pyasn1-modules
+ python3-pyusb
+ python3-qrcode-core
+ python3-yubico
+
 
 [onn-sap]
 name = oVirt Node Optional packages from CentOS Stream $releasever - SAP


### PR DESCRIPTION
Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2017681

## Changes introduced with this PR

* add missing deps for ipa-client on oVirt Node based on CentOS Stream 9

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] yes