### PR TITLE
packaging: split ovirt-release-host-node

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -6,12 +6,17 @@ installdeps:
 srpm: installdeps
 	$(eval SUFFIX=$(shell sh -c " echo '.$$(date -u +%Y%m%d%H%M%S).git$$(git rev-parse --short HEAD)'"))
 	# changing the spec file as passing -D won't preserve the suffix when rebuilding in mock
-	sed "s:%{?release_suffix}:${SUFFIX}:" -i ovirt-release-master.spec.in
-	mkdir -p tmp.repos
+	mkdir -p tmp.repos/SOURCES
 	autoreconf -ivf
 	./configure
 	make dist
+	cp ovirt-release*.tar.gz tmp.repos/SOURCES
+	sed "s:%{?release_suffix}:${SUFFIX}:" -i ovirt-release-master.spec ovirt-release-host-node.spec
 	rpmbuild \
 		-D "_topdir tmp.repos" \
-		-ts ovirt-release*.tar.gz
-	cp tmp.repos/SRPMS/*.src.rpm $(outdir)
+		-bs ovirt-release-master.spec
+	rpmbuild \
+		-D "_topdir tmp.repos" \
+		-bs ovirt-release-host-node.spec
+
+	cp tmp.repos/SRPMS/$(shell sh -c "basename '$(spec)'|cut -f1 -d.")*.src.rpm $(outdir)

--- a/.github/workflows/check-patch.yml
+++ b/.github/workflows/check-patch.yml
@@ -38,7 +38,12 @@ jobs:
       run: make -j distcheck
 
     - name: Build RPM
-      run: rpmbuild -D "_topdir ${PWD}/tmp.repos" -D "release_suffix .$(date -u +%Y%m%d%H%M%S).git$(git rev-parse --short HEAD)" -ta ovirt-release*.tar.gz
+      run: |
+          mkdir -p ${PWD}/tmp.repos/SOURCES
+          cp ovirt-release*.tar.gz ${PWD}/tmp.repos/SOURCES/
+          SUFFIX=$(date -u +%Y%m%d%H%M%S).git$(git rev-parse --short HEAD)
+          rpmbuild -D "_topdir ${PWD}/tmp.repos" -D "release_suffix .${SUFFIX}" -ba ovirt-release-master.spec
+          rpmbuild -D "_topdir ${PWD}/tmp.repos" -D "release_suffix .${SUFFIX}" -ba ovirt-release-host-node.spec
 
     - name: Collect artifacts
       run: |
@@ -60,7 +65,7 @@ jobs:
           yum module enable -y maven:3.5
           yum module enable -y pki-deps:10.6
           yum module enable -y postgresql:12
-          yum --downloadonly install -y exported-artifacts/*noarch.rpm
+          yum --downloadonly install -y exported-artifacts/*noarch.rpm exported-artifacts/*x86_64.rpm
           yum --downloadonly install -y ovirt-engine ovirt-engine-setup-plugin-websocket-proxy
           yum --downloadonly install -y ovirt-engine-appliance
 
@@ -97,7 +102,12 @@ jobs:
       run: make -j distcheck
 
     - name: Build RPM
-      run: rpmbuild -D "_topdir ${PWD}/tmp.repos" -D "release_suffix .$(date -u +%Y%m%d%H%M%S).git$(git rev-parse --short HEAD)" -ta ovirt-release*.tar.gz
+      run: |
+          mkdir -p ${PWD}/tmp.repos/SOURCES
+          cp ovirt-release*.tar.gz ${PWD}/tmp.repos/SOURCES
+          SUFFIX=$(date -u +%Y%m%d%H%M%S).git$(git rev-parse --short HEAD)
+          rpmbuild -D "_topdir ${PWD}/tmp.repos" -D "release_suffix .${SUFFIX}" -ba ovirt-release-master.spec
+          rpmbuild -D "_topdir ${PWD}/tmp.repos" -D "release_suffix .${SUFFIX}" -ba ovirt-release-host-node.spec
 
     - name: Collect artifacts
       run: |
@@ -108,7 +118,7 @@ jobs:
     - name: test install
       run: |
           yum install -y exported-artifacts/ovirt-release-master-4*noarch.rpm
-          yum --downloadonly install -y exported-artifacts/*noarch.rpm
+          yum --downloadonly install -y exported-artifacts/*noarch.rpm exported-artifacts/*x86_64.rpm
 
     - name: Upload artifacts
       uses: ovirt/upload-rpms-action@v1

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -15,7 +15,8 @@ host-node/systemd/system-preset/98-ovirt-host-node.preset
 
 The following files are provided under [LGPL-2.1-or-later](lgpl-2.1.txt) license:
 ```
-Makefile.am:
-configure.ac:
-ovirt-release-master.spec.in:
+Makefile.am
+configure.ac
+ovirt-release-master.spec.in
+ovirt-release-host-node.spec.in
 ```

--- a/Makefile.am
+++ b/Makefile.am
@@ -34,6 +34,8 @@ EXTRA_DIST = \
 	node-optional.el9.repo \
 	ovirt-release-master.spec \
 	ovirt-release-master.spec.in \
+	ovirt-release-host-node.spec.in \
+	ovirt-release-host-node.spec \
 	README.md \
 	$(NULL)
 

--- a/configure.ac
+++ b/configure.ac
@@ -51,6 +51,7 @@ AC_CONFIG_FILES([
             ovirt-el9-stream-ppc64le-deps.repo
             ovirt-el9-stream-x86_64-deps.repo
             ovirt-release-master.spec
+            ovirt-release-host-node.spec
             ovirt-snapshot.repo
 ])
 AC_OUTPUT

--- a/ovirt-release-host-node.spec.in
+++ b/ovirt-release-host-node.spec.in
@@ -1,0 +1,260 @@
+#
+# ovirt-release -- repo files for oVirt projects
+# Copyright (C) 2014-2021 Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+
+%global	host_node_release_file ovirt-release-host-node
+%global	package_version @PACKAGE_VERSION@
+%global	package_name @PACKAGE_NAME@
+%global	package_short_version @PACKAGE_SHORT_VERSION@
+%define debug_package %{nil}
+
+Name: ovirt-release-host-node
+Summary:	The oVirt Node release file
+Version:	@PACKAGE_RPM_VERSION@
+Release:	@PACKAGE_RPM_RELEASE@%{?release_suffix}%{?dist}
+Group:		System Environment/Base
+License:	GPLv2
+URL:		https://www.ovirt.org
+Source0:	https://resources.ovirt.org/pub/ovirt-master-snapshot/src/%{package_name}/%{package_name}-%{package_version}.tar.gz
+
+
+BuildRequires:	automake
+BuildRequires:	autoconf
+BuildRequires:	systemd
+
+Requires:	system-release
+Requires:	tar
+Requires:	python3
+Requires(post): python3-dnf-plugins-core
+
+Requires(post):	systemd
+Requires(post):	firewalld
+Requires(postun):	systemd
+Requires(postun):	firewalld
+
+Requires:	ovirt-node-ng-nodectl
+Requires:	firewalld
+
+%if 0%{?rhel} < 9
+# On CentOS Stream 9 we are going to use ansible 2.11
+# The whole way of consuming anisble roles is going to change
+# skipping ansible dependencies until we have something working.
+Requires:	gluster-ansible-roles
+%endif
+
+Requires:	imgbased
+Requires:	ovirt-host
+Requires:	vdsm-gluster
+Requires:	python3-ovirt-engine-sdk4
+
+# Additional packages for EFI support
+# https://www.brianlane.com/creating-live-isos-with-livemedia-creator.html
+# http://lorax.readthedocs.org/en/latest/livemedia-creator.html#kickstarts
+# Architecture dependent dependencies
+%ifarch x86_64
+Requires:	efibootmgr
+Requires:	grub2-efi-x64
+Requires:	memtest86+
+Requires:	shim
+Requires:	syslinux
+Requires:	iotop
+%endif
+
+%description
+oVirt Node distribution dependencies, presets and required settings.
+
+%package -n ovirt-node-ng-image-update-placeholder
+Summary:	The oVirt Node Image Update Placeholder
+Version:	%{version}
+Release:	%{release}%{?release_suffix}%{?placeholder_release_suffix}%{?dist}
+Group:		System Environment/Base
+License:	GPLv2
+URL:		https://www.ovirt.org
+BuildArch:	noarch
+
+%description -n ovirt-node-ng-image-update-placeholder
+A sub-package to be included into oVirt Node Next squashfs
+image to allow upgrading itself
+
+%prep
+%setup -q -n "%{package_name}-%{package_version}"
+
+%build
+%configure
+make "%{?_smp_mflags}"
+
+
+%install
+rm -rf "%{buildroot}"
+%make_install
+install -d 755 "%{buildroot}/data/images/rhev"
+install -p -d -m 755 %{buildroot}/etc/dnf/protected.d/
+touch ovirt-release-host-node.conf
+echo ovirt-release-host-node > ovirt-release-host-node.conf
+install -p -c -m 0644 ovirt-release-host-node.conf %{buildroot}/etc/dnf/protected.d/
+rm -rf %{buildroot}/usr/share/ovirt-release-master
+
+
+%post
+%define __default_units_wanted cockpit.socket sshd.service NetworkManager.service imgbase-setup.service rsyslog.service auditd.service
+# Make the defualt services default requirements of the target
+for UNIT in %{__default_units_wanted} ; do
+  ln -fs ../$UNIT %{_unitdir}/multi-user.target.wants/$UNIT
+done
+
+#
+# Create the common os-release file
+
+# Import os-release to get some fields
+# NAME, VERSION, ID, VERSION_ID, CPE_NAME
+. /etc/os-release || :
+
+%if 0%{?rhel} < 9
+VERSION_ID="8.6.2202.0"
+%else
+VERSION_ID="9.0.2202.0"
+%endif
+
+install -d /usr/lib/os.release.d/
+cat << EOF > /usr/lib/os.release.d/%{host_node_release_file}
+NAME="$NAME"
+VERSION="$VERSION"
+ID="$ID"
+ID_LIKE="$ID_LIKE"
+VERSION_ID="$VERSION_ID"
+VARIANT="oVirt Node %{package_version}"
+VARIANT_ID="ovirt-node"
+PRETTY_NAME="oVirt Node %{package_short_version}"
+ANSI_COLOR="$ANSI_COLOR"
+CPE_NAME="$CPE_NAME"
+HOME_URL="https://www.ovirt.org/"
+BUG_REPORT_URL="https://bugzilla.redhat.com/"
+EOF
+
+if [[ -n $PLATFORM_ID ]]; then
+    echo "PLATFORM_ID=\"$PLATFORM_ID\"" >> /usr/lib/os.release.d/%{host_node_release_file}
+fi
+
+# Only on installation
+if [ $1 = 1 ]; then
+	cp -p /etc/os-release /usr/lib/os.release.d/.host-node-previous-os-release
+	ln -sf os.release.d/%{host_node_release_file} /usr/lib/os-release
+	ln -sf ../usr/lib/os-release /etc/os-release
+	source /etc/os-release
+	ln -sf %{_prefix}/share/ovirt-release-host-node/branding %{_prefix}/share/cockpit/branding/$ID-ovirt-node
+fi
+
+# Firewalld - add all services required for host
+firewall-offline-cmd --add-service=cockpit >/dev/null 2>&1
+firewall-offline-cmd --add-service=vdsm >/dev/null 2>&1
+firewall-offline-cmd --add-service=libvirt >/dev/null 2>&1
+firewall-offline-cmd --add-service=libvirt-tls >/dev/null 2>&1
+firewall-offline-cmd --add-service=ssh >/dev/null 2>&1
+firewall-offline-cmd --add-service=glusterfs >/dev/null 2>&1
+systemctl restart firewalld.service >/dev/null 2>&1
+
+# Restarting cockpit to load the new branding data
+systemctl restart cockpit.service >/dev/null 2>&1
+
+# Only whitelist:
+# - ovirt-node-ng-image-update
+# - ovirt-engine-appliance
+# - vdsm-hooks and their deps (bz #1947759)
+# set-enabled is needed to keep the repo enabled when post-processing the image
+
+install -m 644 "%{_datadir}/%{package_name}/node-optional%{dist}.repo" "%{_sysconfdir}/yum.repos.d/node-optional.repo"
+
+PYTHON=$(command -v python3 || command -v python)
+
+for REPO in %{_sysconfdir}/yum.repos.d/ovirt-*.repo;
+do
+    $PYTHON << EOF
+try:
+    from ConfigParser import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
+cp = ConfigParser()
+cp.optionxform = str
+cp.read("$REPO")
+for s in cp.sections():
+    cp.remove_option(s, "includepkgs")
+    cp.set(s, "includepkgs", (
+		"ovirt-node-ng-image-update "
+		"ovirt-node-ng-image "
+		"ovirt-engine-appliance "
+		"vdsm-hook-fcoe "
+		"vdsm-hook-vhostmd "
+		"vdsm-hook-openstacknet "
+		"vdsm-hook-ethtool-options")
+	)
+with open("$REPO", "w") as f:
+    f.write("# imgbased: set-enabled\n")
+    cp.write(f)
+EOF
+done
+
+
+#
+# NGN TEMPORARY HACKS
+# For each hack there must be a bug, and they must be removed at
+# some point in time
+# ===================
+
+# =======================
+# NGN TEMPORARY HACKS END
+#
+
+%postun
+for UNIT in %{__default_units_wanted} ; do
+  rm -f %{_unitdir}/multi-user.target.wants/$UNIT
+done
+
+# In case of uninstall the host-node pkg, return the previous os-release
+if [ $1 = 0 ]; then
+	rm -f %{_prefix}/share/cockpit/branding/*-ovirt-node
+	rm -f /usr/lib/os-release /etc/os-release
+	cp -pf /usr/lib/os.release.d/.host-node-previous-os-release /usr/lib/os-release
+	ln -sf /usr/lib/os-release /etc/os-release
+	rm -f /usr/lib/os.release.d/.host-node-previous-os-release
+	firewall-offline-cmd --remove-service=cockpit >/dev/null 2>&1
+	firewall-offline-cmd --remove-service=vdsm >/dev/null 2>&1
+	firewall-offline-cmd --remove-service=libvirt >/dev/null 2>&1
+	firewall-offline-cmd --remove-service=ssh >/dev/null 2>&1
+	systemctl restart firewalld.service >/dev/null 2>&1
+fi
+# Restarting cockpit to reload the branding data
+systemctl restart cockpit.service >/dev/null 2>&1
+
+%files -n ovirt-node-ng-image-update-placeholder
+
+%files
+%ghost %attr(0644, root, root) %{_prefix}/lib/os.release.d/%{host_node_release_file}
+%dir %{_prefix}/share/ovirt-release-host-node
+%dir %{_prefix}/share/ovirt-release-host-node/branding
+%{_presetdir}/98-ovirt-host-node.preset
+%{_prefix}/share/ovirt-release-host-node/branding/*
+%{_sysconfdir}/dnf/protected.d/ovirt-release-host-node.conf
+%license gpl-2.0.txt
+# Add a folder for local datastores
+%dir %attr(0755, vdsm, kvm) /data/images/rhev
+
+%changelog
+* Tue Sep 07 2021 Sandro Bonazzola <sbonazzo@redhat.com> - 4.5.0-0.0.master
+- Bumped version to 4.5.0

--- a/ovirt-release-master.spec.in
+++ b/ovirt-release-master.spec.in
@@ -22,9 +22,6 @@
 %global	package_name @PACKAGE_NAME@
 %global	package_short_version @PACKAGE_SHORT_VERSION@
 %global	ovirt_version @OVIRT_SLOT@
-%define is_x86 %(test %{_arch} = x86_64 && echo 1 || echo 0)
-%global with_node 1
-
 
 Name:		%{package_name}
 Version:	@PACKAGE_RPM_VERSION@
@@ -45,82 +42,14 @@ Requires:	tar
 Requires:	python3
 Requires(post): python3-dnf-plugins-core
 
+
 %description
 This package contains the yum configuration for oVirt repositories
 
 
-%if %{with_node}
-# node supported targets
-%global	host_node_release_file ovirt-release-host-node
-%package -n ovirt-release-host-node
-Summary:	The oVirt Node release file
-Version:	%{version}
-Release:	%{release}%{?release_suffix}%{?dist}
-Group:		System Environment/Base
-License:	GPLv2
-URL:		https://www.ovirt.org
-BuildArch:	noarch
-
-BuildRequires:	systemd
-
-Requires(post):	systemd
-Requires(post):	firewalld
-Requires(postun):	systemd
-Requires(postun):	firewalld
-
-Requires:	ovirt-node-ng-nodectl
-Requires:	firewalld
-
-%if 0%{?rhel} < 9
-# On CentOS Stream 9 we are going to use ansible 2.11
-# The whole way of consuming anisble roles is going to change
-# skipping ansible dependencies until we have something working.
-Requires:	gluster-ansible-roles
-%endif
-
-Requires:	imgbased
-Requires:	ovirt-host
-Requires:	vdsm-gluster
-Requires:	python3-ovirt-engine-sdk4
-
-# Additional packages for EFI support
-# https://www.brianlane.com/creating-live-isos-with-livemedia-creator.html
-# http://lorax.readthedocs.org/en/latest/livemedia-creator.html#kickstarts
-# Architecture dependent dependencies
-%if 0%{?is_x86}
-Requires:	efibootmgr
-
-%if 0%{?fedora}
-Requires:	grub2-efi
-%else
-Requires:	grub2-efi-x64
-%endif
-
-Requires:	memtest86+
-Requires:	shim
-Requires:	syslinux
-Requires:	iotop
-%endif
-
-%description -n ovirt-release-host-node
-oVirt Node distribution dependencies, presets and required settings.
-
-%package -n ovirt-node-ng-image-update-placeholder
-Summary:	The oVirt Node Image Update Placeholder
-Version:	%{version}
-Release:	%{release}%{?release_suffix}%{?placeholder_release_suffix}%{?dist}
-Group:		System Environment/Base
-License:	GPLv2
-URL:		https://www.ovirt.org
-BuildArch:	noarch
-
-%description -n ovirt-node-ng-image-update-placeholder
-A sub-package to be included into oVirt Node Next squashfs
-image to allow upgrading itself
-%endif # node supported targets
-
 %prep
 %setup -q -n "%{package_name}-%{package_version}"
+
 
 %build
 %configure
@@ -136,19 +65,11 @@ install -d 755 "%{buildroot}%{_sysconfdir}/yum.repos.d"
 touch "%{buildroot}%{_sysconfdir}/yum.repos.d/ovirt-%{ovirt_version}-snapshot.repo"
 touch "%{buildroot}%{_sysconfdir}/yum.repos.d/ovirt-%{ovirt_version}-dependencies.repo"
 
-%if %{with_node}
-install -d 755 "%{buildroot}/data/images/rhev"
-install -p -d -m 755 %{buildroot}/etc/dnf/protected.d/
-touch ovirt-release-host-node.conf
-echo ovirt-release-host-node > ovirt-release-host-node.conf
-install -p -c -m 0644 ovirt-release-host-node.conf %{buildroot}/etc/dnf/protected.d/
-%else
 rm -f "%{buildroot}/usr/lib/systemd/system-preset/98-ovirt-host-node.preset"
 rm -rf "%{buildroot}/usr/share/ovirt-release-host-node"
-%endif
+
 
 %post
-
 DISTVER="$(rpm --eval "%%dist"|cut -c2-)"
 ARCH="$(rpm --eval "%%_arch")"
 ID="$(source /etc/os-release && echo $ID)"
@@ -202,154 +123,6 @@ install -m 644 "%{_datadir}/%{package_name}/ovirt-snapshot.repo" "%{_sysconfdir}
 %ghost %config(noreplace) %{_sysconfdir}/yum.repos.d/ovirt-%{ovirt_version}-snapshot.repo
 %doc README.md
 %license LICENSE-2.0.txt
-
-
-%if %{with_node}
-%post -n ovirt-release-host-node
-%define __default_units_wanted cockpit.socket sshd.service NetworkManager.service imgbase-setup.service rsyslog.service auditd.service
-# Make the defualt services default requirements of the target
-for UNIT in %{__default_units_wanted} ; do
-  ln -fs ../$UNIT %{_unitdir}/multi-user.target.wants/$UNIT
-done
-
-#
-# Create the common os-release file
-
-# Import os-release to get some fields
-# NAME, VERSION, ID, VERSION_ID, CPE_NAME
-. /etc/os-release || :
-
-%if 0%{?rhel} < 9
-VERSION_ID="8.6.2109.0"
-%else
-VERSION_ID="9.0.2109.0"
-%endif
-
-install -d /usr/lib/os.release.d/
-cat << EOF > /usr/lib/os.release.d/%{host_node_release_file}
-NAME="$NAME"
-VERSION="$VERSION"
-ID="$ID"
-ID_LIKE="$ID_LIKE"
-VERSION_ID="$VERSION_ID"
-VARIANT="oVirt Node %{package_version}"
-VARIANT_ID="ovirt-node"
-PRETTY_NAME="oVirt Node %{package_short_version}"
-ANSI_COLOR="$ANSI_COLOR"
-CPE_NAME="$CPE_NAME"
-HOME_URL="https://www.ovirt.org/"
-BUG_REPORT_URL="https://bugzilla.redhat.com/"
-EOF
-
-if [[ -n $PLATFORM_ID ]]; then
-    echo "PLATFORM_ID=\"$PLATFORM_ID\"" >> /usr/lib/os.release.d/%{host_node_release_file}
-fi
-
-# Only on installation
-if [ $1 = 1 ]; then
-	cp -p /etc/os-release /usr/lib/os.release.d/.host-node-previous-os-release
-	ln -sf os.release.d/%{host_node_release_file} /usr/lib/os-release
-	ln -sf ../usr/lib/os-release /etc/os-release
-	source /etc/os-release
-	ln -sf %{_prefix}/share/ovirt-release-host-node/branding %{_prefix}/share/cockpit/branding/$ID-ovirt-node
-fi
-
-# Firewalld - add all services required for host
-firewall-offline-cmd --add-service=cockpit >/dev/null 2>&1
-firewall-offline-cmd --add-service=vdsm >/dev/null 2>&1
-firewall-offline-cmd --add-service=libvirt >/dev/null 2>&1
-firewall-offline-cmd --add-service=libvirt-tls >/dev/null 2>&1
-firewall-offline-cmd --add-service=ssh >/dev/null 2>&1
-firewall-offline-cmd --add-service=glusterfs >/dev/null 2>&1
-systemctl restart firewalld.service >/dev/null 2>&1
-
-# Restarting cockpit to load the new branding data
-systemctl restart cockpit.service >/dev/null 2>&1
-
-# Only whitelist:
-# - ovirt-node-ng-image-update
-# - ovirt-engine-appliance
-# - vdsm-hooks and their deps (bz #1947759)
-# set-enabled is needed to keep the repo enabled when post-processing the image
-
-install -m 644 "%{_datadir}/%{package_name}/node-optional%{dist}.repo" "%{_sysconfdir}/yum.repos.d/node-optional.repo"
-
-PYTHON=$(command -v python3 || command -v python)
-
-for REPO in %{_sysconfdir}/yum.repos.d/ovirt-*.repo;
-do
-    $PYTHON << EOF
-try:
-    from ConfigParser import ConfigParser
-except ImportError:
-    from configparser import ConfigParser
-cp = ConfigParser()
-cp.optionxform = str
-cp.read("$REPO")
-for s in cp.sections():
-    cp.remove_option(s, "includepkgs")
-    cp.set(s, "includepkgs", (
-		"ovirt-node-ng-image-update "
-		"ovirt-node-ng-image "
-		"ovirt-engine-appliance "
-		"vdsm-hook-fcoe "
-		"vdsm-hook-vhostmd "
-		"vdsm-hook-openstacknet "
-		"vdsm-hook-ethtool-options")
-	)
-with open("$REPO", "w") as f:
-    f.write("# imgbased: set-enabled\n")
-    cp.write(f)
-EOF
-done
-
-
-#
-# NGN TEMPORARY HACKS
-# For each hack there must be a bug, and they must be removed at
-# some point in time
-# ===================
-
-# =======================
-# NGN TEMPORARY HACKS END
-#
-
-%postun -n ovirt-release-host-node
-for UNIT in %{__default_units_wanted} ; do
-  rm -f %{_unitdir}/multi-user.target.wants/$UNIT
-done
-
-# In case of uninstall the host-node pkg, return the previous os-release
-if [ $1 = 0 ]; then
-	rm -f %{_prefix}/share/cockpit/branding/*-ovirt-node
-	rm -f /usr/lib/os-release /etc/os-release
-	cp -pf /usr/lib/os.release.d/.host-node-previous-os-release /usr/lib/os-release
-	ln -sf /usr/lib/os-release /etc/os-release
-	rm -f /usr/lib/os.release.d/.host-node-previous-os-release
-	firewall-offline-cmd --remove-service=cockpit >/dev/null 2>&1
-	firewall-offline-cmd --remove-service=vdsm >/dev/null 2>&1
-	firewall-offline-cmd --remove-service=libvirt >/dev/null 2>&1
-	firewall-offline-cmd --remove-service=ssh >/dev/null 2>&1
-	systemctl restart firewalld.service >/dev/null 2>&1
-fi
-# Restarting cockpit to reload the branding data
-systemctl restart cockpit.service >/dev/null 2>&1
-
-%files -n ovirt-node-ng-image-update-placeholder
-
-%files -n ovirt-release-host-node
-%ghost %attr(0644, root, root) %{_prefix}/lib/os.release.d/%{host_node_release_file}
-%dir %{_prefix}/share/ovirt-release-host-node
-%dir %{_prefix}/share/ovirt-release-host-node/branding
-%{_presetdir}/98-ovirt-host-node.preset
-%{_prefix}/share/ovirt-release-host-node/branding/*
-%{_sysconfdir}/dnf/protected.d/ovirt-release-host-node.conf
-%license gpl-2.0.txt
-
-
-# Add a folder for local datastores
-%dir %attr(0755, vdsm, kvm) /data/images/rhev
-%endif
 
 %changelog
 * Tue Sep 07 2021 Sandro Bonazzola <sbonazzo@redhat.com> - 4.5.0-0.0.master


### PR DESCRIPTION
## Changes introduced with this PR

splitting ovirt-release-host-node out of ovirt-release-master packaging
because in order to build oVirt Node on CentOS CBS we need the node
related rpms but we don't need the ovirt-release-master rpm itself.

This also allow us to build ovirt-release-master ad noarch and
ovirt-release-host-node as arch specific solving the build issue that
leads to have missing EFI related packages within oVirt Node.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] yes