### PR TITLE
automation: drop advanced-virtualization

### DIFF
--- a/.github/workflows/repoclosure.yml
+++ b/.github/workflows/repoclosure.yml
@@ -39,7 +39,6 @@ jobs:
             --repo baseos \
             --repo extras \
             --repo ovirt-master-centos-opstools-testing \
-            --repo ovirt-master-centos-stream-advanced-virtualization-testing \
             --repo ovirt-master-centos-stream-ceph-pacific \
             --repo ovirt-master-centos-stream-gluster10-testing \
             --repo ovirt-master-centos-stream-nfv-openvswitch2-testing \
@@ -81,7 +80,6 @@ jobs:
             --repo baseos \
             --repo extras \
             --repo ovirt-master-centos-opstools-testing \
-            --repo ovirt-master-centos-stream-advanced-virtualization-testing \
             --repo ovirt-master-centos-stream-ceph-pacific \
             --repo ovirt-master-centos-stream-gluster10-testing \
             --repo ovirt-master-centos-stream-nfv-openvswitch2-testing \


### PR DESCRIPTION


## Changes introduced with this PR

dropping advanced-virtualization repos from repoclosure as it has been
dropped from the needed repositories afte qemu-kvm 6.2 landed in CentOS
Stream 8.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] yes