### PR TITLE
revert the move of ipa-client to node-optional

### DIFF
--- a/node-optional.el8.repo
+++ b/node-optional.el8.repo
@@ -17,34 +17,7 @@ includepkgs =
  python3-librepo
  subscription-manager
  usermode
- #
- # ipa-client
- # https://bugzilla.redhat.com/show_bug.cgi?id=2017681
- autofs
- avahi-libs
- cups-libs
- krb5-workstation
- libipa_hbac
- libkadm5
- libsss_autofs
- libsss_simpleifp
- libsss_sudo
- libwbclient
- python3-dns
- python3-libipa_hbac
- python3-sss
- python3-sss-murmur
- python3-sssdconfig
- samba-client-libs
- samba-common
- samba-common-libs
- sssd-common-pac
- sssd-dbus
- sssd-ipa
- sssd-krb5-common
- sssd-tools
- xmlrpc-c
- xmlrpc-c-client
+
 
 [onn-appstream]
 name = oVirt Node Optional packages from CentOS Stream $releasever - AppStream
@@ -56,24 +29,3 @@ includepkgs =
  # vdsm hooks
  # https://bugzilla.redhat.com/show_bug.cgi?id=1947759
  vhostmd
- #
- # ipa-client
- # https://bugzilla.redhat.com/show_bug.cgi?id=2017681
- certmonger
- ipa-client
- ipa-client-common
- ipa-common
- ipa-selinux
- oddjob
- oddjob-mkhomedir
- python3-click
- python3-gssapi
- python3-ipaclient
- python3-ipalib
- python3-jwcrypto
- python3-ldap
- python3-pyasn1
- python3-pyasn1-modules
- python3-pyusb
- python3-qrcode-core
- python3-yubico

--- a/node-optional.el9.repo
+++ b/node-optional.el9.repo
@@ -11,62 +11,6 @@ includepkgs =
  # vdsm hooks
  # https://bugzilla.redhat.com/show_bug.cgi?id=1947759
  fcoe-utils
- # ipa-client
- # https://bugzilla.redhat.com/show_bug.cgi?id=2017681
- autofs
- cups-libs
- dbus-tools
- krb5-pkinit
- krb5-workstation
- libipa_hbac
- libkadm5
- libsss_autofs
- libwbclient
- python3-dns
- python3-libipa_hbac
- python3-sss
- python3-sss-murmur
- python3-sssdconfig
- samba-client-libs
- samba-common
- samba-common-libs
- sssd-common-pac
- sssd-dbus
- sssd-ipa
- sssd-krb5-common
- sssd-tools
-
-
-[onn-appstream]
-name = oVirt Node Optional packages from CentOS Stream $releasever - AppStream
-metalink = https://mirrors.centos.org/metalink?repo=centos-appstream-$stream&arch=$basearch&protocol=https,http
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
-gpgcheck = 1
-countme = 1
-enabled = 1
-includepkgs =
- # ipa-client
- # https://bugzilla.redhat.com/show_bug.cgi?id=2017681
- certmonger
- ipa-client
- ipa-client-common
- ipa-common
- ipa-selinux
- oddjob
- oddjob-mkhomedir
- python3-babel
- python3-gssapi
- python3-ipaclient
- python3-ipalib
- python3-jinja2
- python3-jwcrypto
- python3-ldap
- python3-markupsafe
- python3-pyasn1
- python3-pyasn1-modules
- python3-pyusb
- python3-qrcode-core
- python3-yubico
 
 
 [onn-sap]


### PR DESCRIPTION
## Changes introduced with this PR

It has been decided to close wontfix BZ#2017681
so reverting the requirement to move ipa-client from mandatory to
optional.

The SCAP guide will be fixed for not requiring ipa-client to be absent
on the system.
## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] yes