### PR TITLE
exclude ansible from Yoga repository

### DIFF
--- a/ovirt-el8-stream-ppc64le-deps.repo.in
+++ b/ovirt-el8-stream-ppc64le-deps.repo.in
@@ -90,6 +90,9 @@ name=CentOS Stream 8 - OpenStack Yoga Repository - testing
 baseurl=https://buildlogs.centos.org/centos/8-stream/cloud/$basearch/openstack-yoga/
 gpgcheck=0
 enabled=1
+exclude=
+ # ansible-2.9.27-4.el8 shipped in yoga repo is breaking dependencies on oVirt side
+ ansible
 
 # As Yoga is under development, also including RDO trunk
 [rdo-delorean-component-cinder]

--- a/ovirt-el8-stream-x86_64-deps.repo.in
+++ b/ovirt-el8-stream-x86_64-deps.repo.in
@@ -95,6 +95,9 @@ name=CentOS Stream 8 - OpenStack Yoga Repository - testing
 baseurl=https://buildlogs.centos.org/centos/8-stream/cloud/$basearch/openstack-yoga/
 gpgcheck=0
 enabled=1
+exclude=
+ # ansible-2.9.27-4.el8 shipped in yoga repo is breaking dependencies on oVirt side
+ ansible
 
 # As Yoga is under development, also including RDO trunk
 [rdo-delorean-component-cinder]


### PR DESCRIPTION
## Changes introduced with this PR

ansible shipped within yoga repo has an epoch higher than the
ansible-core package shipped in CentOS repos.
This is breaking dependencies within the oVirt repos so we are excluding
that package from yoga.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] yes