### PR TITLE
automation: use legacy crypto policy on el9

### DIFF
--- a/.github/workflows/check-patch.yml
+++ b/.github/workflows/check-patch.yml
@@ -83,45 +83,57 @@ jobs:
       image: quay.io/centos/centos:stream9
     if: contains(github.base_ref, 'master') || contains(github.ref, 'master')
     steps:
-    - name: prepare env
-      run: |
-          mkdir -p ${PWD}/tmp.repos/BUILD
-          yum install -y --setopt=tsflags=nodocs autoconf automake gettext-devel git systemd make git rpm-build
+      - name: Use legacy cryptopolicy
+        # as workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2059101
+        # until https://pagure.io/copr/copr/issue/2106 is fixed
+        #
+        # until crypto-policies-20220223-1.git5203b41 lands on mirrors
+        run: |
+            dnf upgrade -y \
+              https://kojihub.stream.centos.org/kojifiles/packages/crypto-policies/20220223/1.git5203b41.el9/noarch/crypto-policies-20220223-1.git5203b41.el9.noarch.rpm \
+              https://kojihub.stream.centos.org/kojifiles/packages/crypto-policies/20220223/1.git5203b41.el9/noarch/crypto-policies-scripts-20220223-1.git5203b41.el9.noarch.rpm
+            dnf upgrade -y crypto-policies-scripts crypto-policies
+            update-crypto-policies --set LEGACY
 
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+      - name: prepare env
+        run: |
+            mkdir -p ${PWD}/tmp.repos/BUILD
+            yum install -y --setopt=tsflags=nodocs autoconf automake gettext-devel git systemd make git rpm-build
 
-    - name: autoreconf
-      run: autoreconf -ivf
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-    - name: configure
-      run: ./configure
+      - name: autoreconf
+        run: autoreconf -ivf
 
-    - name: run distcheck
-      run: make -j distcheck
+      - name: configure
+        run: ./configure
 
-    - name: Build RPM
-      run: |
-          mkdir -p ${PWD}/tmp.repos/SOURCES
-          cp ovirt-release*.tar.gz ${PWD}/tmp.repos/SOURCES
-          SUFFIX=$(date -u +%Y%m%d%H%M%S).git$(git rev-parse --short HEAD)
-          rpmbuild -D "_topdir ${PWD}/tmp.repos" -D "release_suffix .${SUFFIX}" -ba ovirt-release-master.spec
-          rpmbuild -D "_topdir ${PWD}/tmp.repos" -D "release_suffix .${SUFFIX}" -ba ovirt-release-host-node.spec
+      - name: run distcheck
+        run: make -j distcheck
 
-    - name: Collect artifacts
-      run: |
-          mkdir -p exported-artifacts
-          find tmp.repos -iname \*rpm -exec mv "{}" exported-artifacts/ \;
-          mv ./*tar.gz exported-artifacts/
+      - name: Build RPM
+        run: |
+            mkdir -p ${PWD}/tmp.repos/SOURCES
+            cp ovirt-release*.tar.gz ${PWD}/tmp.repos/SOURCES
+            SUFFIX=$(date -u +%Y%m%d%H%M%S).git$(git rev-parse --short HEAD)
+            rpmbuild -D "_topdir ${PWD}/tmp.repos" -D "release_suffix .${SUFFIX}" -ba ovirt-release-master.spec
+            rpmbuild -D "_topdir ${PWD}/tmp.repos" -D "release_suffix .${SUFFIX}" -ba ovirt-release-host-node.spec
 
-    - name: test install
-      run: |
-          yum install -y exported-artifacts/ovirt-release-master-4*noarch.rpm
-          yum --downloadonly install -y exported-artifacts/*noarch.rpm exported-artifacts/*x86_64.rpm
+      - name: Collect artifacts
+        run: |
+            mkdir -p exported-artifacts
+            find tmp.repos -iname \*rpm -exec mv "{}" exported-artifacts/ \;
+            mv ./*tar.gz exported-artifacts/
 
-    - name: Upload artifacts
-      uses: ovirt/upload-rpms-action@v1
-      with:
-        directory: exported-artifacts
-        distro: el9stream
+      - name: test install
+        run: |
+            yum install -y exported-artifacts/ovirt-release-master-4*noarch.rpm
+            yum --downloadonly install -y exported-artifacts/*noarch.rpm exported-artifacts/*x86_64.rpm
+
+      - name: Upload artifacts
+        uses: ovirt/upload-rpms-action@v1
+        with:
+          directory: exported-artifacts
+          distro: el9stream

--- a/.github/workflows/repoclosure.yml
+++ b/.github/workflows/repoclosure.yml
@@ -97,30 +97,42 @@ jobs:
       image: quay.io/centos/centos:stream9
 
     steps:
-    - name: Enable repositories
-      run: |
-          dnf install -y 'dnf-command(copr)'
-          dnf copr enable -y ovirt/ovirt-master-snapshot
-          dnf install -y ovirt-release-master
+      - name: Use legacy cryptopolicy
+        # as workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2059101
+        # until https://pagure.io/copr/copr/issue/2106 is fixed
+        #
+        # until crypto-policies-20220223-1.git5203b41 lands on mirrors
+        run: |
+            dnf upgrade -y \
+              https://kojihub.stream.centos.org/kojifiles/packages/crypto-policies/20220223/1.git5203b41.el9/noarch/crypto-policies-20220223-1.git5203b41.el9.noarch.rpm \
+              https://kojihub.stream.centos.org/kojifiles/packages/crypto-policies/20220223/1.git5203b41.el9/noarch/crypto-policies-scripts-20220223-1.git5203b41.el9.noarch.rpm
+            dnf upgrade -y crypto-policies-scripts crypto-policies
+            update-crypto-policies --set LEGACY
 
-    - name: Run repoclosure on oVirt Master Snapshot from COPR
-      run: |
-          dnf repoclosure --newest --refresh \
-            --check copr:copr.fedorainfracloud.org:ovirt:ovirt-master-snapshot \
-            --repo appstream \
-            --repo baseos \
-            --repo resilientstorage \
-            --repo crb \
-            --repo ovirt-master-centos-stream-ceph-pacific-testing \
-            --repo ovirt-master-centos-stream-gluster10-testing \
-            --repo ovirt-master-centos-stream-nfv-openvswitch2-testing \
-            --repo ovirt-master-centos-stream-openstack-yoga-testing \
-            --repo ovirt-master-centos-stream-opstools-collectd5-testing \
-            --repo ovirt-master-centos-stream-ovirt45-testing \
-            --repo rdo-delorean-component-cinder \
-            --repo rdo-delorean-component-clients \
-            --repo rdo-delorean-component-common \
-            --repo rdo-delorean-component-network
+      - name: Enable repositories
+        run: |
+            dnf install -y 'dnf-command(copr)'
+            dnf copr enable -y ovirt/ovirt-master-snapshot
+            dnf install -y ovirt-release-master
+
+      - name: Run repoclosure on oVirt Master Snapshot from COPR
+        run: |
+            dnf repoclosure --newest --refresh \
+              --check copr:copr.fedorainfracloud.org:ovirt:ovirt-master-snapshot \
+              --repo appstream \
+              --repo baseos \
+              --repo resilientstorage \
+              --repo crb \
+              --repo ovirt-master-centos-stream-ceph-pacific-testing \
+              --repo ovirt-master-centos-stream-gluster10-testing \
+              --repo ovirt-master-centos-stream-nfv-openvswitch2-testing \
+              --repo ovirt-master-centos-stream-openstack-yoga-testing \
+              --repo ovirt-master-centos-stream-opstools-collectd5-testing \
+              --repo ovirt-master-centos-stream-ovirt45-testing \
+              --repo rdo-delorean-component-cinder \
+              --repo rdo-delorean-component-clients \
+              --repo rdo-delorean-component-common \
+              --repo rdo-delorean-component-network
 
   ovirt-master-centos-stream-ovirt45-testing-el9:
     runs-on: ubuntu-latest
@@ -128,29 +140,42 @@ jobs:
       image: quay.io/centos/centos:stream9
 
     steps:
-    - name: Enable repositories
-      run: |
-          dnf install -y 'dnf-command(copr)'
-          dnf copr enable -y ovirt/ovirt-master-snapshot
-          dnf install -y ovirt-release-master
+      - name: Use legacy cryptopolicy
+        # as workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2059101
+        # until https://pagure.io/copr/copr/issue/2106 is fixed
+        #
+        # until crypto-policies-20220223-1.git5203b41 lands on mirrors
+        run: |
+            dnf upgrade -y \
+              https://kojihub.stream.centos.org/kojifiles/packages/crypto-policies/20220223/1.git5203b41.el9/noarch/crypto-policies-20220223-1.git5203b41.el9.noarch.rpm \
+              https://kojihub.stream.centos.org/kojifiles/packages/crypto-policies/20220223/1.git5203b41.el9/noarch/crypto-policies-scripts-20220223-1.git5203b41.el9.noarch.rpm
+            dnf upgrade -y crypto-policies-scripts crypto-policies
+            update-crypto-policies --set LEGACY
 
-    - name: Run repoclosure on oVirt Master Snapshot from COPR
-      run: |
-          dnf repoclosure --newest --refresh \
-            --check ovirt-master-centos-stream-ovirt45-testing \
-            --repo appstream \
-            --repo baseos \
-            --repo crb \
-            --repo ovirt-master-centos-stream-ceph-pacific-testing \
-            --repo ovirt-master-centos-stream-gluster10-testing \
-            --repo ovirt-master-centos-stream-nfv-openvswitch2-testing \
-            --repo ovirt-master-centos-stream-openstack-yoga-testing \
-            --repo ovirt-master-centos-stream-opstools-collectd5-testing \
-            --repo rdo-delorean-component-cinder \
-            --repo rdo-delorean-component-clients \
-            --repo rdo-delorean-component-common \
-            --repo rdo-delorean-component-network \
-            --repo resilientstorage
+
+      - name: Enable repositories
+        run: |
+            dnf install -y 'dnf-command(copr)'
+            dnf copr enable -y ovirt/ovirt-master-snapshot
+            dnf install -y ovirt-release-master
+
+      - name: Run repoclosure on oVirt Master Snapshot from COPR
+        run: |
+            dnf repoclosure --newest --refresh \
+              --check ovirt-master-centos-stream-ovirt45-testing \
+              --repo appstream \
+              --repo baseos \
+              --repo crb \
+              --repo ovirt-master-centos-stream-ceph-pacific-testing \
+              --repo ovirt-master-centos-stream-gluster10-testing \
+              --repo ovirt-master-centos-stream-nfv-openvswitch2-testing \
+              --repo ovirt-master-centos-stream-openstack-yoga-testing \
+              --repo ovirt-master-centos-stream-opstools-collectd5-testing \
+              --repo rdo-delorean-component-cinder \
+              --repo rdo-delorean-component-clients \
+              --repo rdo-delorean-component-common \
+              --repo rdo-delorean-component-network \
+              --repo resilientstorage
 
   centos-release-ovirt45-el8:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes issue #117

## Changes introduced with this PR

recent openssl dropped support for sha1 algo but COPR and several
other packaging systems are still signing RPMS with sha1.
In order to be able to install RPMs switching from default crypto policy
to legacy one untill RPMS with newer sha signature will be provided.

This requires [crypto-policies-20220223-1.git5203b41.el9](https://kojihub.stream.centos.org/koji/buildinfo?buildID=17332) which is not yet
on c9s mirrors but should land there soon.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] yes