### PR TITLE
yoga: set module_hotfixes

### DIFF
--- a/ovirt-el8-stream-ppc64le-deps.repo.in
+++ b/ovirt-el8-stream-ppc64le-deps.repo.in
@@ -90,6 +90,7 @@ name=CentOS Stream 8 - OpenStack Yoga Repository - testing
 baseurl=https://buildlogs.centos.org/centos/8-stream/cloud/$basearch/openstack-yoga/
 gpgcheck=0
 enabled=1
+module_hotfixes=1
 exclude=
  # ansible-2.9.27-4.el8 shipped in yoga repo is breaking dependencies on oVirt side
  ansible

--- a/ovirt-el8-stream-x86_64-deps.repo.in
+++ b/ovirt-el8-stream-x86_64-deps.repo.in
@@ -95,6 +95,7 @@ name=CentOS Stream 8 - OpenStack Yoga Repository - testing
 baseurl=https://buildlogs.centos.org/centos/8-stream/cloud/$basearch/openstack-yoga/
 gpgcheck=0
 enabled=1
+module_hotfixes=1
 exclude=
  # ansible-2.9.27-4.el8 shipped in yoga repo is breaking dependencies on oVirt side
  ansible


### PR DESCRIPTION
## Changes introduced with this PR

yoga testing is shipping python-sqlalchemy which is newer than the one
shipped in CentOS Stream under modularity filtering.
Setting module_hotfixes for yoga repo for overriding the filtering.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] yes