### PR TITLE
decouple node and release rpms

### DIFF
--- a/ovirt-release-host-node.spec.in
+++ b/ovirt-release-host-node.spec.in
@@ -110,6 +110,8 @@ touch ovirt-release-host-node.conf
 echo ovirt-release-host-node > ovirt-release-host-node.conf
 install -p -c -m 0644 ovirt-release-host-node.conf %{buildroot}/etc/dnf/protected.d/
 rm -rf %{buildroot}/usr/share/ovirt-release45
+install -d 755 "%{buildroot}%{_sysconfdir}/yum.repos.d"
+install -m 644 "node-optional%{dist}.repo" "%{buildroot}%{_sysconfdir}/yum.repos.d/node-optional.repo"
 
 
 %post
@@ -178,8 +180,6 @@ systemctl restart cockpit.service >/dev/null 2>&1
 # - ovirt-engine-appliance
 # - vdsm-hooks and their deps (bz #1947759)
 # set-enabled is needed to keep the repo enabled when post-processing the image
-
-install -m 644 "%{_datadir}/%{package_name}/node-optional%{dist}.repo" "%{_sysconfdir}/yum.repos.d/node-optional.repo"
 
 PYTHON=$(command -v python3 || command -v python)
 
@@ -251,6 +251,7 @@ systemctl restart cockpit.service >/dev/null 2>&1
 %{_presetdir}/98-ovirt-host-node.preset
 %{_prefix}/share/ovirt-release-host-node/branding/*
 %{_sysconfdir}/dnf/protected.d/ovirt-release-host-node.conf
+%{_sysconfdir}/yum.repos.d/node-optional.repo
 %license gpl-2.0.txt
 # Add a folder for local datastores
 %dir %attr(0755, vdsm, kvm) /data/images/rhev

--- a/ovirt-release45.spec.in
+++ b/ovirt-release45.spec.in
@@ -67,7 +67,8 @@ touch "%{buildroot}%{_sysconfdir}/yum.repos.d/ovirt-%{ovirt_version}-dependencie
 
 rm -f "%{buildroot}/usr/lib/systemd/system-preset/98-ovirt-host-node.preset"
 rm -rf "%{buildroot}/usr/share/ovirt-release-host-node"
-
+rm -f "%{buildroot}/usr/share/ovirt-release45/node-optional.el8.repo"
+rm -f "%{buildroot}/usr/share/ovirt-release45/node-optional.el9.repo"
 
 %post
 DISTVER="$(rpm --eval "%%dist"|cut -c2-)"
@@ -115,7 +116,7 @@ install -m 644 "%{_datadir}/%{package_name}/ovirt-snapshot.repo" "%{_sysconfdir}
 
 
 %files
-%{_datadir}/%{package_name}/
+%{_datadir}/%{package_name}/ovirt*
 # We do not know what distribution we are installed at,
 # we copy the actual files at post, but still wants this package to own them.
 # ghost in this case solves that issue


### PR DESCRIPTION
## Changes introduced with this PR

Moved node repos config to ovirt-release-host-node to ensure it works even when ovirt-release rpm is not installed.

This is needed in order to be able to use centos-release-ovirt45 rpm instead.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] yes