### PR TITLE
Use CentOS Stream 8 opstools repository

### DIFF
--- a/ovirt-el8-stream-ppc64le-deps.repo.in
+++ b/ovirt-el8-stream-ppc64le-deps.repo.in
@@ -74,8 +74,8 @@ enabled=1
 module_hotfixes=1
 
 [ovirt-@OVIRT_SLOT@-centos-opstools-testing]
-name=CentOS-8 - OpsTools - collectd
-baseurl=https://buildlogs.centos.org/centos/8/opstools/$basearch/collectd-5/
+name=CentOS Stream 8 - OpsTools - collectd
+baseurl=https://buildlogs.centos.org/centos/8-stream/opstools/$basearch/collectd-5/
 gpgcheck=0
 enabled=1
 

--- a/ovirt-el8-stream-x86_64-deps.repo.in
+++ b/ovirt-el8-stream-x86_64-deps.repo.in
@@ -79,8 +79,8 @@ enabled=1
 module_hotfixes=1
 
 [ovirt-@OVIRT_SLOT@-centos-opstools-testing]
-name=CentOS-8 - OpsTools - collectd
-baseurl=https://buildlogs.centos.org/centos/8/opstools/$basearch/collectd-5/
+name=CentOS Stream 8 - OpsTools - collectd
+baseurl=https://buildlogs.centos.org/centos/8-stream/opstools/$basearch/collectd-5/
 gpgcheck=0
 enabled=1
 


### PR DESCRIPTION
Use CentOS Stream 9 opstools repository instead of CentOS 8 repository
for oVirt release master and 4.5

Signed-off-by: Martin Perina <mperina@redhat.com>
