### PR TITLE
filter out ansible-test from yoga too

### DIFF
--- a/ovirt-el8-stream-ppc64le-deps.repo.in
+++ b/ovirt-el8-stream-ppc64le-deps.repo.in
@@ -94,6 +94,7 @@ module_hotfixes=1
 exclude=
  # ansible-2.9.27-4.el8 shipped in yoga repo is breaking dependencies on oVirt side
  ansible
+ ansible-test
 
 # As Yoga is under development, also including RDO trunk
 [rdo-delorean-component-cinder]

--- a/ovirt-el8-stream-x86_64-deps.repo.in
+++ b/ovirt-el8-stream-x86_64-deps.repo.in
@@ -99,6 +99,7 @@ module_hotfixes=1
 exclude=
  # ansible-2.9.27-4.el8 shipped in yoga repo is breaking dependencies on oVirt side
  ansible
+ ansible-test
 
 # As Yoga is under development, also including RDO trunk
 [rdo-delorean-component-cinder]


### PR DESCRIPTION
we use ansible-test in ovirt-ansible-collection

Fixes issue # (delete if not relevant)

## Changes introduced with this PR

*

*

*

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n]