### PR TITLE
node: Remove gluster-ansible-roles

### DIFF
--- a/ovirt-release-host-node.spec.in
+++ b/ovirt-release-host-node.spec.in
@@ -52,12 +52,7 @@ Requires(postun):	firewalld
 Requires:	ovirt-node-ng-nodectl
 Requires:	firewalld
 
-%if 0%{?rhel} < 9
-# On CentOS Stream 9 we are going to use ansible 2.11
-# The whole way of consuming anisble roles is going to change
-# skipping ansible dependencies until we have something working.
-Requires:	gluster-ansible-roles
-%endif
+# TODO: Restore gluster-ansible-roles once it's upgraded to ansible-core 2.12
 
 Requires:	imgbased
 Requires:	ovirt-host


### PR DESCRIPTION
It's not ported to ansible-core, which is now required for
ovirt-ansible-collection, including hosted-engine deployment
functionality.

Change-Id: Ic2c17b9248cfa73da92e478c34762b8440ce07a7
Signed-off-by: Yedidyah Bar David <didi@redhat.com>

Fixes issue # (delete if not relevant)

## Changes introduced with this PR

*

*

*

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n]