### PR TITLE
el8: drop advanced virtualization

### DIFF
--- a/ovirt-el8-ppc64le-deps.repo.in
+++ b/ovirt-el8-ppc64le-deps.repo.in
@@ -61,15 +61,6 @@ repo_gpgcheck=0
 enabled=1
 enabled_metadata=1
 
-# Once CentOS Stream derivatives will start providing 8.6 content we can drop this repo as
-# advanced virtualization is going to be included in AppStream.
-[ovirt-@OVIRT_SLOT@-centos-stream-advanced-virtualization-testing]
-name=Advanced Virtualization CentOS Stream testing packages for $basearch
-baseurl=https://buildlogs.centos.org/centos/8-stream/virt/$basearch/advancedvirt-common/
-enabled=1
-gpgcheck=0
-module_hotfixes=1
-
 [ovirt-@OVIRT_SLOT@-centos-stream-ovirt45-testing]
 name=CentOS Stream 8 - oVirt 4.5 - testing
 baseurl=https://buildlogs.centos.org/centos/8-stream/virt/$basearch/ovirt-45/

--- a/ovirt-el8-x86_64-deps.repo.in
+++ b/ovirt-el8-x86_64-deps.repo.in
@@ -66,15 +66,6 @@ repo_gpgcheck=0
 enabled=1
 enabled_metadata=1
 
-# Once CentOS Stream derivatives will start providing 8.6 content we can drop this repo as
-# advanced virtualization is going to be included in AppStream.
-[ovirt-@OVIRT_SLOT@-centos-stream-advanced-virtualization-testing]
-name=Advanced Virtualization CentOS Stream testing packages for $basearch
-baseurl=https://buildlogs.centos.org/centos/8-stream/virt/$basearch/advancedvirt-common/
-enabled=1
-gpgcheck=0
-module_hotfixes=1
-
 [ovirt-@OVIRT_SLOT@-centos-stream-ovirt45-testing]
 name=CentOS Stream 8 - oVirt 4.5 - testing
 baseurl=https://buildlogs.centos.org/centos/8-stream/virt/$basearch/ovirt-45/


### PR DESCRIPTION
## Changes introduced with this PR

* Now that RHEL 8.6 Beta has been released there's no reason to keep advanced virtualization repos for non-stream distributions.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] y