### PR TITLE
automation: use centos-gluster10 on el8

### DIFF
--- a/.github/workflows/repoclosure-45.yml
+++ b/.github/workflows/repoclosure-45.yml
@@ -42,7 +42,7 @@ jobs:
               --repo centos-ceph-pacific \
               --repo centos-nfv-openvswitch \
               --repo centos-opstools \
-              --repo ovirt-45-centos-stream-gluster10 \
+              --repo centos-gluster10 \
               --repo ovirt-45-centos-stream-openstack-yoga-testing \
               --repo centos-openstack-xena
 

--- a/.github/workflows/repoclosure.yml
+++ b/.github/workflows/repoclosure.yml
@@ -128,7 +128,7 @@ jobs:
             --repo centos-ceph-pacific \
             --repo centos-nfv-openvswitch \
             --repo centos-opstools \
-            --repo ovirt-45-centos-stream-gluster10 \
+            --repo centos-gluster10 \
             --repo ovirt-45-centos-stream-openstack-yoga-testing \
             --repo centos-openstack-xena
 


### PR DESCRIPTION
Fixes issue #152

## Changes introduced with this PR

Using official `centos-gluster10` repo id instead of the custom
`ovirt-45-centos-stream-gluster10` id which we provided as workaround for
the missing release rpm on el8.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] y