### PR TITLE
Exclude protobuf from Openstack and Ceph

### DIFF
--- a/ovirt-el8-stream-ppc64le-deps.repo.in
+++ b/ovirt-el8-stream-ppc64le-deps.repo.in
@@ -84,6 +84,8 @@ name=CentOS Stream 8 - Ceph packages for $basearch
 baseurl=http://mirror.centos.org/centos/8-stream/storage/$basearch/ceph-pacific
 enabled=1
 gpgcheck=0
+exclude=
+ protobuf
 
 [ovirt-@OVIRT_SLOT@-centos-stream-openstack-yoga-testing]
 name=CentOS Stream 8 - OpenStack Yoga Repository - testing
@@ -95,6 +97,7 @@ exclude=
  # ansible-2.9.27-4.el8 shipped in yoga repo is breaking dependencies on oVirt side
  ansible
  ansible-test
+ protobuf
 
 # As Yoga is under development, also including RDO trunk
 [rdo-delorean-component-cinder]

--- a/ovirt-el8-stream-x86_64-deps.repo.in
+++ b/ovirt-el8-stream-x86_64-deps.repo.in
@@ -89,6 +89,8 @@ name=CentOS Stream 8 - Ceph packages for $basearch
 baseurl=http://mirror.centos.org/centos/8-stream/storage/$basearch/ceph-pacific
 enabled=1
 gpgcheck=0
+exclude=
+ protobuf
 
 [ovirt-@OVIRT_SLOT@-centos-stream-openstack-yoga-testing]
 name=CentOS Stream 8 - OpenStack Yoga Repository - testing
@@ -100,6 +102,7 @@ exclude=
  # ansible-2.9.27-4.el8 shipped in yoga repo is breaking dependencies on oVirt side
  ansible
  ansible-test
+ protobuf
 
 # As Yoga is under development, also including RDO trunk
 [rdo-delorean-component-cinder]


### PR DESCRIPTION
The protobuf package provided by Openstack
and Ceph repo is not compatible with usbguard.
This results in dnf update fail. Exclude protobuf
from Openstack and Ceph repo.

Signed-off-by: Ales Musil <amusil@redhat.com>