### PR TITLE
Revert "node: Remove gluster-ansible-roles"

### DIFF
--- a/ovirt-release-host-node.spec.in
+++ b/ovirt-release-host-node.spec.in
@@ -52,7 +52,12 @@ Requires(postun):	firewalld
 Requires:	ovirt-node-ng-nodectl
 Requires:	firewalld
 
-# TODO: Restore gluster-ansible-roles once it's upgraded to ansible-core 2.12
+%if 0%{?rhel} < 9
+# On CentOS Stream 9 we are going to use ansible 2.11
+# The whole way of consuming anisble roles is going to change
+# skipping ansible dependencies until we have something working.
+Requires:	gluster-ansible-roles
+%endif
 
 Requires:	imgbased
 Requires:	ovirt-host


### PR DESCRIPTION

Fixes issue #145

## Changes introduced with this PR

This reverts commit 22fbbb961c577c3ee022424f8580df917c77fdaa.

New glusterr-ansible-roles are compatible with ansible-core 2.12

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] y