### PR TITLE
el9: include gluster-ansible-roles within node el9

### DIFF
--- a/ovirt-release-host-node.spec.in
+++ b/ovirt-release-host-node.spec.in
@@ -52,12 +52,7 @@ Requires(postun):	firewalld
 Requires:	ovirt-node-ng-nodectl
 Requires:	firewalld
 
-%if 0%{?rhel} < 9
-# On CentOS Stream 9 we are going to use ansible 2.11
-# The whole way of consuming anisble roles is going to change
-# skipping ansible dependencies until we have something working.
 Requires:	gluster-ansible-roles
-%endif
 
 Requires:	imgbased
 Requires:	ovirt-host


### PR DESCRIPTION
## Changes introduced with this PR

* Now that gluster-ansible-roles supports ansible-core 2.12 adding it to el9 build too

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] y