### PR TITLE
oVirt Engine 4.5 requires enabling mod_auth_openidc

### DIFF
--- a/.github/workflows/check-patch.yml
+++ b/.github/workflows/check-patch.yml
@@ -66,6 +66,7 @@ jobs:
             dnf module enable -y maven:3.5
             dnf module enable -y pki-deps:10.6
             dnf module enable -y postgresql:12
+            dnf module enable -y mod_auth_openidc:2.3
             dnf --downloadonly install -y exported-artifacts/*noarch.rpm exported-artifacts/*x86_64.rpm
             dnf --downloadonly install -y ovirt-engine ovirt-engine-setup-plugin-websocket-proxy
             dnf --downloadonly install -y ovirt-engine-appliance

--- a/.github/workflows/repoclosure-45.yml
+++ b/.github/workflows/repoclosure-45.yml
@@ -29,6 +29,7 @@ jobs:
             dnf module enable -y maven:3.5
             dnf module enable -y pki-deps:10.6
             dnf module enable -y postgresql:12
+            dnf module enable -y mod_auth_openidc:2.3
             dnf module enable -y ruby:3.0
 
       - name: Run repoclosure on oVirt 4.5 Released content

--- a/.github/workflows/repoclosure.yml
+++ b/.github/workflows/repoclosure.yml
@@ -30,6 +30,7 @@ jobs:
             dnf module enable -y maven:3.5
             dnf module enable -y pki-deps:10.6
             dnf module enable -y postgresql:12
+            dnf module enable -y mod_auth_openidc:2.3
             dnf module enable -y ruby:3.0
 
       - name: Run repoclosure on oVirt Master Snapshot from COPR
@@ -106,6 +107,7 @@ jobs:
             dnf module enable -y maven:3.5
             dnf module enable -y pki-deps:10.6
             dnf module enable -y postgresql:12
+            dnf module enable -y mod_auth_openidc:2.3
             dnf module enable -y ruby:3.0
 
       - name: Run repoclosure on CentOS Virtualization SIG - oVirt 45 - testing


### PR DESCRIPTION
ovirt-engine >= 4.5.0 requires enabling mod_auth_openidc module due to
dependency on mod_auth_openidc package required for KeyCloak integration
as mentioned in https://bugzilla.redhat.com/2021497

Signed-off-by: Martin Perina <mperina@redhat.com>
