### PR TITLE
[4.5] oVirt Engine 4.5 requires enabling mod_auth_openidc

### DIFF
--- a/.github/workflows/check-patch.yml
+++ b/.github/workflows/check-patch.yml
@@ -65,6 +65,7 @@ jobs:
           yum module enable -y maven:3.5
           yum module enable -y pki-deps:10.6
           yum module enable -y postgresql:12
+          yum module enable -y mod_auth_openidc:2.3
           yum --downloadonly install -y exported-artifacts/*noarch.rpm exported-artifacts/*x86_64.rpm
           yum --downloadonly install -y ovirt-engine ovirt-engine-setup-plugin-websocket-proxy
           yum --downloadonly install -y ovirt-engine-appliance

--- a/.github/workflows/repoclosure-45.yml
+++ b/.github/workflows/repoclosure-45.yml
@@ -28,6 +28,7 @@ jobs:
             dnf module enable -y maven:3.5
             dnf module enable -y pki-deps:10.6
             dnf module enable -y postgresql:12
+            dnf module enable -y mod_auth_openidc:2.3
             dnf module enable -y ruby:3.0
 
       - name: Run repoclosure on oVirt 4.5 Released content

--- a/.github/workflows/repoclosure.yml
+++ b/.github/workflows/repoclosure.yml
@@ -29,6 +29,7 @@ jobs:
           dnf module enable -y maven:3.5
           dnf module enable -y pki-deps:10.6
           dnf module enable -y postgresql:12
+          dnf module enable -y mod_auth_openidc:2.3
           dnf module enable -y ruby:3.0
 
     - name: Run repoclosure on oVirt Master Snapshot from COPR
@@ -112,6 +113,7 @@ jobs:
           dnf module enable -y maven:3.5
           dnf module enable -y pki-deps:10.6
           dnf module enable -y postgresql:12
+          dnf module enable -y mod_auth_openidc:2.3
           dnf module enable -y ruby:3.0
 
     - name: Run repoclosure on CentOS Virtualization SIG - oVirt 45 - testing


### PR DESCRIPTION
ovirt-engine >= 4.5.0 requires enabling mod_auth_openidc module due to
dependency on mod_auth_openidc package required for KeyCloak integration
as mentioned in https://bugzilla.redhat.com/2021497

Signed-off-by: Martin Perina <mperina@redhat.com>
(cherry picked from commit cfb74c849b37ecb60f0f331536981cf1264cd38f)