### PR TITLE
el8 deps: remove ansible include from epel

### DIFF
--- a/ovirt-el8-ppc64le-deps.repo.in
+++ b/ovirt-el8-ppc64le-deps.repo.in
@@ -4,7 +4,6 @@ name=Extra Packages for Enterprise Linux 8 - $basearch
 metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-8&arch=$basearch&infra=$infra&content=$contentdir
 enabled=1
 includepkgs=
- ansible
  ansible-doc
  epel-release
  facter

--- a/ovirt-el8-stream-ppc64le-deps.repo.in
+++ b/ovirt-el8-stream-ppc64le-deps.repo.in
@@ -4,7 +4,6 @@ name=Extra Packages for Enterprise Linux 8 - $basearch
 metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-8&arch=$basearch&infra=$infra&content=$contentdir
 enabled=1
 includepkgs=
- ansible
  ansible-doc
  epel-release
  facter

--- a/ovirt-el8-stream-x86_64-deps.repo.in
+++ b/ovirt-el8-stream-x86_64-deps.repo.in
@@ -4,7 +4,6 @@ name=Extra Packages for Enterprise Linux 8 - $basearch
 metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-8&arch=$basearch&infra=$infra&content=$contentdir
 enabled=1
 includepkgs=
- ansible
  ansible-doc
  epel-release
  facter

--- a/ovirt-el8-x86_64-deps.repo.in
+++ b/ovirt-el8-x86_64-deps.repo.in
@@ -4,7 +4,6 @@ name=Extra Packages for Enterprise Linux 8 - $basearch
 metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-8&arch=$basearch&infra=$infra&content=$contentdir
 enabled=1
 includepkgs=
- ansible
  ansible-doc
  epel-release
  facter


### PR DESCRIPTION
The epel provides ansible version 5 which confits with HE setup installation which requires ansible<2.10. 