### PR TITLE
host-node: fix

### DIFF
--- a/ovirt-release-host-node.spec.in
+++ b/ovirt-release-host-node.spec.in
@@ -183,27 +183,26 @@ PYTHON=$(command -v python3 || command -v python)
 for REPO in %{_sysconfdir}/yum.repos.d/CentOS-oVirt-*.repo;
 do
     $PYTHON << EOF
-try:
-    from ConfigParser import ConfigParser
-except ImportError:
-    from configparser import ConfigParser
+import os
+from configparser import ConfigParser
 cp = ConfigParser()
 cp.optionxform = str
-cp.read("$REPO")
-for s in cp.sections():
-    cp.remove_option(s, "includepkgs")
-    cp.set(s, "includepkgs", (
-		"ovirt-node-ng-image-update "
-		"ovirt-node-ng-image "
-		"ovirt-engine-appliance "
-		"vdsm-hook-fcoe "
-		"vdsm-hook-vhostmd "
-		"vdsm-hook-openstacknet "
-		"vdsm-hook-ethtool-options")
-	)
-with open("$REPO", "w") as f:
-    f.write("# imgbased: set-enabled\n")
-    cp.write(f)
+if os.path.exists("$REPO"):
+	cp.read("$REPO")
+	for s in cp.sections():
+		cp.remove_option(s, "includepkgs")
+		cp.set(s, "includepkgs", (
+			"ovirt-node-ng-image-update "
+			"ovirt-node-ng-image "
+			"ovirt-engine-appliance "
+			"vdsm-hook-fcoe "
+			"vdsm-hook-vhostmd "
+			"vdsm-hook-openstacknet "
+			"vdsm-hook-ethtool-options")
+		)
+	with open("$REPO", "w") as f:
+		f.write("# imgbased: set-enabled\n")
+		cp.write(f)
 EOF
 done
 


### PR DESCRIPTION
## Changes introduced with this PR
avoid creation of `/etc/yum.repos.d/'CentOS-oVirt-*.repo'` when the 4.5 rpm is installed without centos-release-ovirt45 (it happens on master builds)

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n]