### PR TITLE
Fix includepkgs since oVirt 4.5

### DIFF
--- a/ovirt-release-host-node.spec.in
+++ b/ovirt-release-host-node.spec.in
@@ -180,7 +180,7 @@ systemctl restart cockpit.service >/dev/null 2>&1
 
 PYTHON=$(command -v python3 || command -v python)
 
-for REPO in %{_sysconfdir}/yum.repos.d/ovirt-*.repo;
+for REPO in %{_sysconfdir}/yum.repos.d/ovirt-*.repo %{_sysconfdir}/yum.repos.d/CentOS-oVirt-*.repo;
 do
     $PYTHON << EOF
 try:


### PR DESCRIPTION
Since the repo files of oVirt changed in 4.5, we fail to set the
includepkgs value now.

Also check the includepkgs in %{_sysconfdir}/yum.repos.d/CentOS-oVirt-*.repo

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2100002
Signed-off-by: Jean-Louis Dupond <jean-louis@dupond.be>