### PR TITLE
repoclosure-45: use rockylinux/8

### DIFF
--- a/.github/workflows/repoclosure-45.yml
+++ b/.github/workflows/repoclosure-45.yml
@@ -50,7 +50,7 @@ jobs:
   centos-release-ovirt45-rocky-linux-8:
     runs-on: ubuntu-latest
     container:
-      image: rockylinux:latest
+      image: rockylinux:8
     steps:
       - name: Enable repositories
         run: |


### PR DESCRIPTION
Fixes issue #238

## Changes introduced with this PR

* rockylinux/latest seems not available anymore after Rocky Linux 9 GA.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

y