### PR TITLE
el8: Exclude the rdo OvS/OVN packages

### DIFF
--- a/ovirt-el8-ppc64le-deps.repo.in
+++ b/ovirt-el8-ppc64le-deps.repo.in
@@ -64,3 +64,8 @@ exclude=
  # ansible-2.9.27-4.el8 shipped in yoga repo is breaking dependencies on oVirt side
  ansible
  ansible-test
+ rdo-openvswitch
+ rdo-ovn
+ rdo-ovn-central
+ rdo-ovn-host
+ python3-rdo-openvswitch

--- a/ovirt-el8-stream-ppc64le-deps.repo.in
+++ b/ovirt-el8-stream-ppc64le-deps.repo.in
@@ -58,3 +58,8 @@ exclude=
  # ansible-2.9.27-4.el8 shipped in yoga repo is breaking dependencies on oVirt side
  ansible
  ansible-test
+ rdo-openvswitch
+ rdo-ovn
+ rdo-ovn-central
+ rdo-ovn-host
+ python3-rdo-openvswitch

--- a/ovirt-el8-stream-x86_64-deps.repo.in
+++ b/ovirt-el8-stream-x86_64-deps.repo.in
@@ -57,3 +57,8 @@ exclude=
  # ansible-2.9.27-4.el8 shipped in yoga repo is breaking dependencies on oVirt side
  ansible
  ansible-test
+ rdo-openvswitch
+ rdo-ovn
+ rdo-ovn-central
+ rdo-ovn-host
+ python3-rdo-openvswitch

--- a/ovirt-el8-x86_64-deps.repo.in
+++ b/ovirt-el8-x86_64-deps.repo.in
@@ -64,3 +64,8 @@ exclude=
  # ansible-2.9.27-4.el8 shipped in yoga repo is breaking dependencies on oVirt side
  ansible
  ansible-test
+ rdo-openvswitch
+ rdo-ovn
+ rdo-ovn-central
+ rdo-ovn-host
+ python3-rdo-openvswitch


### PR DESCRIPTION
To prevent any conflict exclude OvS and OVN packages from OpenStack.

