### PR TITLE
build: 4.5.3.2 Async

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@ dnl
 dnl SPDX-License-Identifier: LGPL-2.1-or-later
 
 
-define([VERSION_NUMBER], [4.5.3.1])
+define([VERSION_NUMBER], [4.5.3.2])
 define([VERSION_SUFFIX], [])
 
 AC_INIT([ovirt-release45], VERSION_NUMBER[]VERSION_SUFFIX, [devel@ovirt.org])

--- a/ovirt-release-host-node.spec.in
+++ b/ovirt-release-host-node.spec.in
@@ -281,6 +281,9 @@ systemctl restart cockpit.service >/dev/null 2>&1
 %dir %attr(0755, vdsm, kvm) /data/images/rhev
 
 %changelog
+* Thu Oct 27 2022 Lev Veyde <lveyde@redhat.com> - 4.5.3.2-1
+- Bumped for 4.5.3.2 Async
+
 * Wed Oct 19 2022 Lev Veyde <lveyde@redhat.com> - 4.5.3.1-1
 - Bumped for 4.5.3.1 Async
 


### PR DESCRIPTION
Signed-off-by: Lev Veyde <lveyde@redhat.com>

## Changes introduced with this PR

* Bump patch for ovirt-release-host-node 4.5.3.2 Async release

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]