### PR TITLE
github: address Node.js 12 deprecation

### DIFF
--- a/.github/workflows/check-patch.yml
+++ b/.github/workflows/check-patch.yml
@@ -25,7 +25,7 @@ jobs:
             dnf distro-sync -y
             dnf install -y --setopt=tsflags=nodocs autoconf automake gettext-devel git systemd make git rpm-build
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -91,7 +91,7 @@ jobs:
             dnf distro-sync -y
             dnf install -y --setopt=tsflags=nodocs autoconf automake gettext-devel git systemd make git rpm-build
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/repoclosure-45.yml
+++ b/.github/workflows/repoclosure-45.yml
@@ -233,7 +233,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Add a comment about successful job and close issue
         run: |
           set -e
@@ -263,7 +263,7 @@ jobs:
       - centos-release-ovirt45-stream9
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Add a comment about failed job
         run: |
           set -e

--- a/.github/workflows/repoclosure.yml
+++ b/.github/workflows/repoclosure.yml
@@ -160,7 +160,7 @@ jobs:
       - centos-release-ovirt45-el9
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Add a comment about successful job and close issue
         run: |
           set -e
@@ -185,7 +185,7 @@ jobs:
       - centos-release-ovirt45-el9
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Add a comment about failed job
         run: |
           set -e


### PR DESCRIPTION
## Changes introduced with this PR

* address Node.js 12 deprecation warning in GitHub actions execution

> Node.js 12 actions are deprecated.
> For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
> Please update the following actions to use Node.js 16: actions/checkout@v2


## Are you the owner of the code you are sending in, or do you have permission of the owner?

y