### PR TITLE
github: update to oVirt/upload-rpms-action@main

### DIFF
--- a/.github/workflows/check-patch.yml
+++ b/.github/workflows/check-patch.yml
@@ -72,11 +72,9 @@ jobs:
             dnf --downloadonly install -y ovirt-engine-appliance
 
       - name: Upload artifacts
-        uses: ovirt/upload-rpms-action@v1
+        uses: ovirt/upload-rpms-action@main
         with:
           directory: exported-artifacts
-          distro: el8stream
-
 
   build-el9:
     # Building only on master as we don't support el9 in 4.4.
@@ -124,7 +122,6 @@ jobs:
             dnf --downloadonly install -y exported-artifacts/*noarch.rpm exported-artifacts/*x86_64.rpm
 
       - name: Upload artifacts
-        uses: ovirt/upload-rpms-action@v1
+        uses: ovirt/upload-rpms-action@main
         with:
           directory: exported-artifacts
-          distro: el9stream


### PR DESCRIPTION
## Changes introduced with this PR

* addresses:
> Node.js 12 actions are deprecated.
> For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
> Please update the following actions to use Node.js 16: actions/upload-artifact@v2

## Are you the owner of the code you are sending in, or do you have permission of the owner?

y