### PR TITLE
el9: Exclude RDO OvS/OVN packages

### DIFF
--- a/ovirt-el9-stream-aarch64-deps.repo.in
+++ b/ovirt-el9-stream-aarch64-deps.repo.in
@@ -34,3 +34,8 @@ name=CentOS Stream 9 - OpenStack Yoga Repository - testing
 baseurl=https://buildlogs.centos.org/9-stream/cloud/$basearch/openstack-yoga/
 gpgcheck=0
 enabled=1
+exclude=
+ python3-rdo-openvswitch
+ rdo-openvswitch
+ rdo-ovn
+ rdo-ovn-central

--- a/ovirt-el9-stream-ppc64le-deps.repo.in
+++ b/ovirt-el9-stream-ppc64le-deps.repo.in
@@ -34,3 +34,9 @@ name=CentOS Stream 9 - OpenStack Yoga Repository - testing
 baseurl=https://buildlogs.centos.org/9-stream/cloud/$basearch/openstack-yoga/
 gpgcheck=0
 enabled=1
+exclude=
+ python3-rdo-openvswitch
+ rdo-openvswitch
+ rdo-ovn
+ rdo-ovn-central
+ rdo-ovn-host

--- a/ovirt-el9-stream-x86_64-deps.repo.in
+++ b/ovirt-el9-stream-x86_64-deps.repo.in
@@ -34,3 +34,8 @@ name=CentOS Stream 9 - OpenStack Yoga Repository - testing
 baseurl=https://buildlogs.centos.org/9-stream/cloud/$basearch/openstack-yoga/
 gpgcheck=0
 enabled=1
+exclude=
+ python3-rdo-openvswitch
+ rdo-openvswitch
+ rdo-ovn
+ rdo-ovn-central


### PR DESCRIPTION
To prevent any conflicts exclude OvS and OVN packages
from OpenStack.

Signed-off-by: Martin Perina <mperina@redhat.com>
