### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/check-patch.yml
+++ b/.github/workflows/check-patch.yml
@@ -25,7 +25,7 @@ jobs:
             dnf distro-sync -y
             dnf install -y --setopt=tsflags=nodocs autoconf automake gettext-devel git systemd make git rpm-build
 
-      - uses: actions/checkout@v3
+      - uses: ovirt/checkout-action@main
         with:
           fetch-depth: 0
 

--- a/.github/workflows/repoclosure-45.yml
+++ b/.github/workflows/repoclosure-45.yml
@@ -235,7 +235,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: ovirt/checkout-action@main
       - name: Add a comment about successful job and close issue
         run: |
           set -e
@@ -265,7 +265,7 @@ jobs:
       - centos-release-ovirt45-stream9
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: ovirt/checkout-action@main
       - name: Add a comment about failed job
         run: |
           set -e

--- a/.github/workflows/repoclosure.yml
+++ b/.github/workflows/repoclosure.yml
@@ -160,7 +160,7 @@ jobs:
       - centos-release-ovirt45-el9
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: ovirt/checkout-action@main
       - name: Add a comment about successful job and close issue
         run: |
           set -e
@@ -185,7 +185,7 @@ jobs:
       - centos-release-ovirt45-el9
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: ovirt/checkout-action@main
       - name: Add a comment about failed job
         run: |
           set -e


### PR DESCRIPTION
## Changes introduced with this PR

* switch to `ovirt/checkout-action@main` within actions. Solves: `Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3.` warning.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

y