### PR TITLE
Add SIG Virt ovirt-45 repository on c10s

### DIFF
--- a/ovirt-el10-stream-aarch64-deps.repo.in
+++ b/ovirt-el10-stream-aarch64-deps.repo.in
@@ -1,5 +1,11 @@
 # CentOS 10 SIGs dependencies
 
+[ovirt-@OVIRT_SLOT@-centos-stream-ovirt45-testing]
+name=CentOS Stream 10 - oVirt 4.5 - testing
+baseurl=https://buildlogs.centos.org/centos/10-stream/virt/$basearch/ovirt-45/
+gpgcheck=0
+enabled=1
+
 [ovirt-@OVIRT_SLOT@-centos-stream-nfv-openvswitch2-testing]
 name=CentOS Stream 10 - NFV OpenVSwitch 2 - testing
 baseurl=https://buildlogs.centos.org/centos/10-stream/nfv/$basearch/openvswitch-2/

--- a/ovirt-el10-stream-ppc64le-deps.repo.in
+++ b/ovirt-el10-stream-ppc64le-deps.repo.in
@@ -1,5 +1,11 @@
 # CentOS 10 SIGs dependencies
 
+[ovirt-@OVIRT_SLOT@-centos-stream-ovirt45-testing]
+name=CentOS Stream 10 - oVirt 4.5 - testing
+baseurl=https://buildlogs.centos.org/centos/10-stream/virt/$basearch/ovirt-45/
+gpgcheck=0
+enabled=1
+
 [ovirt-@OVIRT_SLOT@-centos-stream-nfv-openvswitch2-testing]
 name=CentOS Stream 10 - NFV OpenVSwitch 2 - testing
 baseurl=https://buildlogs.centos.org/centos/10-stream/nfv/$basearch/openvswitch-2/

--- a/ovirt-el10-stream-s390x-deps.repo.in
+++ b/ovirt-el10-stream-s390x-deps.repo.in
@@ -1,5 +1,11 @@
 # CentOS 10 SIGs dependencies
 
+[ovirt-@OVIRT_SLOT@-centos-stream-ovirt45-testing]
+name=CentOS Stream 10 - oVirt 4.5 - testing
+baseurl=https://buildlogs.centos.org/centos/10-stream/virt/$basearch/ovirt-45/
+gpgcheck=0
+enabled=1
+
 [ovirt-@OVIRT_SLOT@-centos-stream-nfv-openvswitch2-testing]
 name=CentOS Stream 10 - NFV OpenVSwitch 2 - testing
 baseurl=https://buildlogs.centos.org/centos/10-stream/nfv/$basearch/openvswitch-2/

--- a/ovirt-el10-stream-x86_64-deps.repo.in
+++ b/ovirt-el10-stream-x86_64-deps.repo.in
@@ -1,5 +1,11 @@
 # CentOS 10 SIGs dependencies
 
+[ovirt-@OVIRT_SLOT@-centos-stream-ovirt45-testing]
+name=CentOS Stream 10 - oVirt 4.5 - testing
+baseurl=https://buildlogs.centos.org/centos/10-stream/virt/$basearch/ovirt-45/
+gpgcheck=0
+enabled=1
+
 [ovirt-@OVIRT_SLOT@-centos-stream-nfv-openvswitch2-testing]
 name=CentOS Stream 10 - NFV OpenVSwitch 2 - testing
 baseurl=https://buildlogs.centos.org/centos/10-stream/nfv/$basearch/openvswitch-2/


### PR DESCRIPTION
Add the ovirt-45 repository from SIG Virt to CentOS Stream 10.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]