### PR TITLE
ovirt-release-host-node.spec: drop gluster on el10

### DIFF
--- a/ovirt-release-host-node.spec.in
+++ b/ovirt-release-host-node.spec.in
@@ -55,11 +55,14 @@ Requires(postun):	firewalld
 Requires:	ovirt-node-ng-nodectl
 Requires:	firewalld
 
+# Gluster is not build since EL10
+%if 0%{?rhel} <= 9
 Requires:	gluster-ansible-roles
+Requires:	vdsm-gluster
+%endif
 
 Requires:	imgbased
 Requires:	ovirt-host
-Requires:	vdsm-gluster
 Requires:	python3-ovirt-engine-sdk4
 
 # Additional packages for EFI support


### PR DESCRIPTION
As gluster is EOL and not build on EL10, don't require gluster related packages anymore since el10.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]