### PR TITLE
Drop ResilientStorage

### DIFF
--- a/.github/workflows/repoclosure.yml
+++ b/.github/workflows/repoclosure.yml
@@ -57,7 +57,6 @@ jobs:
               --check copr:copr.fedorainfracloud.org:ovirt:ovirt-master-snapshot \
               --repo appstream \
               --repo baseos \
-              --repo resilientstorage \
               --repo crb \
               ${{ matrix.additional_repos }}
 
@@ -106,7 +105,6 @@ jobs:
               --check ovirt-45-upstream-testing \
               --repo appstream \
               --repo baseos \
-              --repo resilientstorage \
               --repo crb \
               ${{ matrix.additional_repos }}
 

--- a/ovirt-release-master.spec.in
+++ b/ovirt-release-master.spec.in
@@ -97,8 +97,6 @@ then
 	# centos macro is defined on centos-like distributions
 	# Ensuring crb repository is enabled
 	dnf config-manager --set-enabled crb
-	# Ensuring resilientstorage repository is enabled
-	dnf config-manager --set-enabled resilientstorage
 fi
 
 if [ $CENTOS -ge 10 ]


### PR DESCRIPTION
ResilientStorage does not exist anymore on AlmaLinux 10. The packages we need are in AppStream, so we can safely drop the usage of ResilientStorage.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]