### PR TITLE
ovirt-release-master.spec: enable appliance on el10

### DIFF
--- a/ovirt-release-master.spec.in
+++ b/ovirt-release-master.spec.in
@@ -101,9 +101,8 @@ fi
 
 if [ $CENTOS -ge 10 ]
 then
-	# appliance and node not available yet on el10
+	# node not available on el10
 	dnf config-manager --set-disabled ovirt-node-master-snapshot
-	dnf config-manager --set-disabled ovirt-appliance-master-snapshot
 	# Enable EPEL if it would have been disabled
 	if [ -f /etc/yum.repos.d/epel.repo ] ; then
 		dnf config-manager --set-enabled epel


### PR DESCRIPTION
We have ovirt-appliance available on el10 now.
Enable it by default.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]